### PR TITLE
replacing in_irq() function with newer in_hardirq()

### DIFF
--- a/drivers/aic8800/aic8800_fdrv/aic_priv_cmd.c
+++ b/drivers/aic8800/aic8800_fdrv/aic_priv_cmd.c
@@ -324,6 +324,8 @@ static int aic_priv_cmd_set_tx (struct rwnx_hw *rwnx_hw, int argc, char *argv[],
 			lvl_mod = 1;
 		else if (settx_param.mode == 5)
 			lvl_mod = 2;
+		else
+			lvl_mod = 0;
 		if (settx_param.mode >= 4)
 			lvl_idx = settx_param.rate & 0xF;
 		else if (settx_param.mode >= 2)

--- a/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
@@ -1840,11 +1840,13 @@ static int aicwf_usb_bus_txdata(struct device *dev, struct sk_buff *skb)
 #else
     if (!IS_ALIGNED((unsigned long)buf, align_param)) {
         usb_buf->usb_align_data = (u8*)kmalloc(sizeof(u8) * buf_len + align_param, GFP_ATOMIC);
-        if (usb_buf->usb_align_data) {
-            align = ((unsigned long)(usb_buf->usb_align_data)) & (align_param - 1);
-            buf_align = usb_buf->usb_align_data + (align_param - align);
-            memcpy(buf_align, buf, buf_len);
+        if (!usb_buf->usb_align_data) {
+            usb_err("kmalloc fail\n");
+            return -ENOMEM;
         }
+        align = ((unsigned long)(usb_buf->usb_align_data)) & (align_param - 1);
+        buf_align = usb_buf->usb_align_data + (align_param - align);
+        memcpy(buf_align, buf, buf_len);
     } else {
         buf_align = buf;
     }

--- a/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
@@ -1626,7 +1626,7 @@ void reord_deinit_sta(struct aicwf_rx_priv* rx_priv, struct reord_ctrl_info *reo
             reord_rxframe_free(&rx_priv->freeq_lock, &rx_priv->rxframes_freequeue, &req->rxframe_list);
         }
 
-		AICWFDBG(LOGINFO, "reord dinit in_irq():%d in_atomic:%d in_softirq:%d\r\n", (int)in_irq()
+		AICWFDBG(LOGINFO, "reord dinit in_hardirq():%d in_atomic:%d in_softirq:%d\r\n", (int)in_hardirq()
 			,(int)in_atomic(), (int)in_softirq());
         spin_unlock_bh(&preorder_ctrl->reord_list_lock);
     }


### PR DESCRIPTION
fixing compilation crash on modern linux