### PR TITLE
Fix debug messaging bugs and complete printk conversion

### DIFF
--- a/drivers/aic8800/Makefile
+++ b/drivers/aic8800/Makefile
@@ -72,9 +72,9 @@ modules:
 install_firmware:
 	@test -d $(FIRMWARE_PATH) || { echo "ERROR: Firmware directory $(FIRMWARE_PATH) not found" >&2; exit 1; }
 	@echo "Installing firmware to $(FIRMWARE_DEST)..."
-	if [ ! -d "$(FIRMWARE_DEST)" ]; then \
-		@echo "Creating $(FIRMWARE_DEST)"; \
-		mkdir -p $(FIRMWARE_DEST); \
+	@if [ ! -d "$(FIRMWARE_DEST)" ]; then \
+		echo "Creating $(FIRMWARE_DEST)"; \
+		sudo mkdir -p $(FIRMWARE_DEST); \
 	fi
 	sudo cp -rf $(FIRMWARE_PATH)/* $(FIRMWARE_DEST)
 

--- a/drivers/aic8800/aic8800_fdrv/aic_br_ext.c
+++ b/drivers/aic8800/aic8800_fdrv/aic_br_ext.c
@@ -1544,10 +1544,10 @@ void dhcp_flag_bcast(struct rwnx_vif *vif, struct sk_buff *skb)
 void *scdb_findEntry(struct rwnx_vif *vif, unsigned char *macAddr,
 		     unsigned char *ipAddr)
 {
-	AICWFDBG(LOGINFO, "%s()\n",__func__);
 	unsigned char networkAddr[MAX_NETWORK_ADDR_LEN];
 	struct nat25_network_db_entry *db;
 	int hash;
+	AICWFDBG(LOGINFO, "%s()\n",__func__);
 	/* _irqL irqL; */
 	/* _enter_critical_bh(&priv->br_ext_lock, &irqL); */
 

--- a/drivers/aic8800/aic8800_fdrv/aic_priv_cmd.c
+++ b/drivers/aic8800/aic8800_fdrv/aic_priv_cmd.c
@@ -1602,10 +1602,10 @@ static const struct aic_priv_cmd aic_priv_commands[] = {
 static void print_help(const char *cmd)
 {
 	int n;
-	AICWFDBG(LOGERROR, "commands:\n");
+	AICWFDBG(LOGINFO, "commands:\n");
 	for (n = 0; aic_priv_commands[n].cmd; n++) {
 		if (cmd != NULL)
-			AICWFDBG(LOGERROR, "%s %s\n", aic_priv_commands[n].cmd, aic_priv_commands[n].usage);
+			AICWFDBG(LOGINFO, "%s %s\n", aic_priv_commands[n].cmd, aic_priv_commands[n].usage);
 	}
 }
 

--- a/drivers/aic8800/aic8800_fdrv/rwnx_cfgfile.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_cfgfile.c
@@ -60,7 +60,7 @@ int rwnx_parse_configfile(struct rwnx_hw *rwnx_hw, const char *filename,
     RWNX_DBG(RWNX_FN_ENTRY_STR);
 
     if ((ret = request_firmware(&config_fw, filename, rwnx_hw->dev))) {
-        printk(KERN_CRIT "%s: Failed to get %s (%d)\n", __func__, filename, ret);
+        AICWFDBG(LOGERROR, "%s: Failed to get %s (%d)\n", __func__, filename, ret);
         return ret;
     }
 
@@ -98,7 +98,7 @@ int rwnx_parse_phy_configfile(struct rwnx_hw *rwnx_hw, const char *filename,
     RWNX_DBG(RWNX_FN_ENTRY_STR);
 
     if ((ret = request_firmware(&config_fw, filename, rwnx_hw->dev))) {
-        printk(KERN_CRIT "%s: Failed to get %s (%d)\n", __func__, filename, ret);
+        AICWFDBG(LOGERROR, "%s: Failed to get %s (%d)\n", __func__, filename, ret);
         return ret;
     }
 

--- a/drivers/aic8800/aic8800_fdrv/rwnx_cmds.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_cmds.c
@@ -34,7 +34,7 @@ void rwnx_cmd_free(struct rwnx_cmd *cmd);
 
 static void cmd_dump(const struct rwnx_cmd *cmd)
 {
-    printk(KERN_CRIT "tkn[%d]  flags:%04x  result:%3d  cmd:%4d-%-24s - reqcfm(%4d-%-s)\n",
+    AICWFDBG(LOGERROR, "tkn[%d]  flags:%04x  result:%3d  cmd:%4d-%-24s - reqcfm(%4d-%-s)\n",
            cmd->tkn, cmd->flags, cmd->result, cmd->id, RWNX_ID2STR(cmd->id),
            cmd->reqid, cmd->reqid != (lmac_msg_id_t)-1 ? RWNX_ID2STR(cmd->reqid) : "none");
 }
@@ -76,7 +76,7 @@ int cmd_mgr_queue_force_defer(struct rwnx_cmd_mgr *cmd_mgr, struct rwnx_cmd *cmd
     spin_lock_bh(&cmd_mgr->lock);
 
     if (cmd_mgr->state == RWNX_CMD_MGR_STATE_CRASHED) {
-        printk(KERN_CRIT"cmd queue crashed\n");
+        AICWFDBG(LOGERROR, "cmd queue crashed\n");
         cmd->result = -EPIPE;
         spin_unlock_bh(&cmd_mgr->lock);
         return -EPIPE;
@@ -85,7 +85,7 @@ int cmd_mgr_queue_force_defer(struct rwnx_cmd_mgr *cmd_mgr, struct rwnx_cmd *cmd
     #ifndef CONFIG_RWNX_FHOST
     if (!list_empty(&cmd_mgr->cmds)) {
         if (cmd_mgr->queue_sz == cmd_mgr->max_queue_sz) {
-            printk(KERN_CRIT"Too many cmds (%d) already queued\n",
+            AICWFDBG(LOGERROR, "Too many cmds (%d) already queued\n",
                    cmd_mgr->max_queue_sz);
             cmd->result = -ENOMEM;
             spin_unlock_bh(&cmd_mgr->lock);
@@ -161,7 +161,7 @@ static int cmd_mgr_queue(struct rwnx_cmd_mgr *cmd_mgr, struct rwnx_cmd *cmd)
     } else {
 			spin_lock_bh(&cmd_mgr->lock);
 			if (cmd_mgr->state == RWNX_CMD_MGR_STATE_CRASHED) {
-				printk(KERN_CRIT"cmd queue crashed\n");
+				AICWFDBG(LOGERROR, "cmd queue crashed\n");
 				cmd->result = -EPIPE;
 				spin_unlock_bh(&cmd_mgr->lock);
 				return -EPIPE;
@@ -173,7 +173,7 @@ static int cmd_mgr_queue(struct rwnx_cmd_mgr *cmd_mgr, struct rwnx_cmd *cmd)
         struct rwnx_cmd *last;
 
         if (cmd_mgr->queue_sz == cmd_mgr->max_queue_sz) {
-            printk(KERN_CRIT"Too many cmds (%d) already queued\n",
+            AICWFDBG(LOGERROR, "Too many cmds (%d) already queued\n",
                    cmd_mgr->max_queue_sz);
             cmd->result = -ENOMEM;
             spin_unlock_bh(&cmd_mgr->lock);
@@ -183,7 +183,7 @@ static int cmd_mgr_queue(struct rwnx_cmd_mgr *cmd_mgr, struct rwnx_cmd *cmd)
         if (last->flags & (RWNX_CMD_FLAG_WAIT_ACK | RWNX_CMD_FLAG_WAIT_PUSH | RWNX_CMD_FLAG_WAIT_CFM)) {
 #if 0 // queue even NONBLOCK command.
             if (cmd->flags & RWNX_CMD_FLAG_NONBLOCK) {
-                printk(KERN_CRIT"cmd queue busy\n");
+                AICWFDBG(LOGERROR, "cmd queue busy\n");
                 cmd->result = -EBUSY;
                 spin_unlock_bh(&cmd_mgr->lock);
                 return -EBUSY;
@@ -258,7 +258,7 @@ static int cmd_mgr_queue(struct rwnx_cmd_mgr *cmd_mgr, struct rwnx_cmd *cmd)
         #else
         unsigned long tout = msecs_to_jiffies(RWNX_80211_CMD_TIMEOUT_MS/*AIDEN workaround* cmd_mgr->queue_sz*/);
         if (!wait_for_completion_killable_timeout(&cmd->complete, tout)) {
-            printk(KERN_CRIT"%s cmd timed-out cmd_mgr->queue_sz:%d\n", __func__,cmd_mgr->queue_sz);
+            AICWFDBG(LOGERROR, "%s cmd timed-out cmd_mgr->queue_sz:%d\n", __func__,cmd_mgr->queue_sz);
         #ifdef AICWF_SDIO_SUPPORT
             ret = aicwf_sdio_writeb(sdiodev, SDIOWIFI_WAKEUP_REG, 2);
             if (ret < 0) {
@@ -322,7 +322,7 @@ static int cmd_mgr_llind(struct rwnx_cmd_mgr *cmd_mgr, struct rwnx_cmd *cmd)
         }
     }
     if (!acked) {
-        printk(KERN_CRIT "Error: acked cmd not found\n");
+        AICWFDBG(LOGERROR, "Error: acked cmd not found\n");
     } else {
         cmd->flags &= ~RWNX_CMD_FLAG_WAIT_ACK;
         if (RWNX_CMD_WAIT_COMPLETE(cmd->flags))
@@ -385,7 +385,7 @@ void cmd_mgr_task_process(struct work_struct *work)
 
             tout = msecs_to_jiffies(RWNX_80211_CMD_TIMEOUT_MS * cmd_mgr->queue_sz);
             if (!wait_for_completion_killable_timeout(&next->complete, tout)) {
-                printk(KERN_CRIT"%s cmd timed-out cmd_mgr->queue_sz:%d\n", __func__, cmd_mgr->queue_sz);
+                AICWFDBG(LOGERROR, "%s cmd timed-out cmd_mgr->queue_sz:%d\n", __func__, cmd_mgr->queue_sz);
                 cmd_dump(next);
                 spin_lock_bh(&cmd_mgr->lock);
                 //AIDEN  workaround  
@@ -572,7 +572,7 @@ void aicwf_set_cmd_tx(void *dev, struct lmac_msg *msg, uint len)
 	struct aic_usb_dev *usbdev = (struct aic_usb_dev *)dev;
 	struct aicwf_bus *bus = NULL;
     if (!usbdev->state) {
-        printk("down msg \n");
+        AICWFDBG(LOGINFO, "down msg \n");
         return;
     }
 	bus = usbdev->bus_if;

--- a/drivers/aic8800/aic8800_fdrv/rwnx_fw_dump.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_fw_dump.c
@@ -481,7 +481,7 @@ int rwnx_um_helper(struct rwnx_debugfs *rwnx_debugfs, const char *cmd)
 
     if ((ret = call_usermodehelper(argv[0], argv, envp,
                                    UMH_WAIT_PROC | UMH_KILLABLE)))
-        printk(KERN_CRIT "Failed to call %s (%s returned %d)\n",
+        AICWFDBG(LOGERROR, "Failed to call %s (%s returned %d)\n",
                argv[0], cmd, ret);
     argv_free(argv);
 

--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -82,7 +82,7 @@ static char *wifi_mac_addr = 0;
 extern char country_code[];
 
 #define RWNX_PRINT_CFM_ERR(req) \
-        printk(KERN_CRIT "%s: Status Error(%d)\n", #req, (&req##_cfm)->status)
+        AICWFDBG(LOGERROR, "%s: Status Error(%d)\n", #req, (&req##_cfm)->status)
 
 #define RWNX_HT_CAPABILITIES                                    \
 {                                                               \
@@ -700,59 +700,59 @@ static void rwnx_frame_parser(char* tag, char* data, unsigned long len){
 
 #if 0
 	if(data[0] == ASSOC_REQ){
-		printk("%s %s ASSOC_REQ \r\n", __func__, tag);
+		AICWFDBG(LOGTRACE, "%s %s ASSOC_REQ \r\n", __func__, tag);
 	}else if(data[0] == ASSOC_RSP){
-		printk("%s %s ASSOC_RSP \r\n", __func__, tag);
+		AICWFDBG(LOGTRACE, "%s %s ASSOC_RSP \r\n", __func__, tag);
 	}else if(data[0] == PROBE_REQ){
-		printk("%s %s PROBE_REQ \r\n", __func__, tag);
+		AICWFDBG(LOGTRACE, "%s %s PROBE_REQ \r\n", __func__, tag);
 	}else if(data[0] == PROBE_RSP){
-		printk("%s %s PROBE_RSP \r\n", __func__, tag);
+		AICWFDBG(LOGTRACE, "%s %s PROBE_RSP \r\n", __func__, tag);
 	}else if(data[0] == ACTION){
-		printk("%s %s ACTION ", __func__, tag);
+		AICWFDBG(LOGTRACE, "%s %s ACTION ", __func__, tag);
 		if(data[ACTION_MAC_HDR_LEN] == 0x04 && data[ACTION_MAC_HDR_LEN + 6] == 0x00){
-			printk("GO NEG REQ \r\n");
+			AICWFDBG(LOGTRACE, "GO NEG REQ \r\n");
 		}else if(data[ACTION_MAC_HDR_LEN] == 0x04 && data[ACTION_MAC_HDR_LEN + 6] == 0x01){
-			printk("GO NEG RSP \r\n");
+			AICWFDBG(LOGTRACE, "GO NEG RSP \r\n");
 		}else if(data[ACTION_MAC_HDR_LEN] == 0x04 && data[ACTION_MAC_HDR_LEN + 6] == 0x02){
-			printk("GO NEG CFM \r\n");
+			AICWFDBG(LOGTRACE, "GO NEG CFM \r\n");
 		}else if(data[ACTION_MAC_HDR_LEN] == 0x04 && data[ACTION_MAC_HDR_LEN + 6] == 0x03){
-			printk("P2P INV REQ \r\n");
+			AICWFDBG(LOGTRACE, "P2P INV REQ \r\n");
 		}else if(data[ACTION_MAC_HDR_LEN] == 0x04 && data[ACTION_MAC_HDR_LEN + 6] == 0x04){
-			printk("P2P INV RSP \r\n");
+			AICWFDBG(LOGTRACE, "P2P INV RSP \r\n");
 		}else if(data[ACTION_MAC_HDR_LEN] == 0x04 && data[ACTION_MAC_HDR_LEN + 6] == 0x05){
-			printk("DD REQ \r\n");
+			AICWFDBG(LOGTRACE, "DD REQ \r\n");
 		}else if(data[ACTION_MAC_HDR_LEN] == 0x04 && data[ACTION_MAC_HDR_LEN + 6] == 0x06){
-			printk("DD RSP \r\n");
+			AICWFDBG(LOGTRACE, "DD RSP \r\n");
 		}else if(data[ACTION_MAC_HDR_LEN] == 0x04 && data[ACTION_MAC_HDR_LEN + 6] == 0x07){
-			printk("PD REQ \r\n");
+			AICWFDBG(LOGTRACE, "PD REQ \r\n");
 		}else if(data[ACTION_MAC_HDR_LEN] == 0x04 && data[ACTION_MAC_HDR_LEN + 6] == 0x08){
-			printk("PD RSP \r\n");
+			AICWFDBG(LOGTRACE, "PD RSP \r\n");
 		}else{
-			printk("\r\n");
+			AICWFDBG(LOGTRACE, "\r\n");
 		}
 
 	}else if(data[0] == AUTH){
-		printk("%s %s AUTH \r\n", __func__, tag);
+		AICWFDBG(LOGTRACE, "%s %s AUTH \r\n", __func__, tag);
 	}else if(data[0] == DEAUTH){
-		printk("%s %s DEAUTH \r\n", __func__, tag);
+		AICWFDBG(LOGTRACE, "%s %s DEAUTH \r\n", __func__, tag);
 	}else if(data[0] == QOS){
 		if(data[QOS_MAC_HDR_LEN + 6] == 0x88 && data[QOS_MAC_HDR_LEN + 7] == 0x8E){
-			printk("%s %s QOS 802.1X ", __func__, tag);
+			AICWFDBG(LOGTRACE, "%s %s QOS 802.1X ", __func__, tag);
 			if(data[QOS_MAC_HDR_LEN + 9] == 0x03){
-				printk("EAPOL");
+				AICWFDBG(LOGTRACE, "EAPOL");
 			}else if(data[QOS_MAC_HDR_LEN + 9] == 0x00){
-				printk("EAP PACKAGE ");
+				AICWFDBG(LOGTRACE, "EAP PACKAGE ");
 				if(data[QOS_MAC_HDR_LEN + 12] == 0x01){
-					printk("EAP REQ\r\n");
+					AICWFDBG(LOGTRACE, "EAP REQ\r\n");
 				}else if(data[QOS_MAC_HDR_LEN + 12] == 0x02){
-					printk("EAP RSP\r\n");
+					AICWFDBG(LOGTRACE, "EAP RSP\r\n");
 				}else if(data[QOS_MAC_HDR_LEN + 12] == 0x04){
-					printk("EAP FAIL\r\n");
+					AICWFDBG(LOGTRACE, "EAP FAIL\r\n");
 				}else{
-					printk("\r\n");
+					AICWFDBG(LOGTRACE, "\r\n");
 				}
 			}else if(data[QOS_MAC_HDR_LEN + 9] == 0x01){
-				printk("EAP START \r\n");
+				AICWFDBG(LOGTRACE, "EAP START \r\n");
 
 			}
 		}
@@ -8318,7 +8318,7 @@ static void rf_config(struct rwnx_hw *rwnx_hw)
     ret = rwnx_send_dbg_mem_mask_write_req(rwnx_hw,
                 rf_tbl_masked[0][0], rf_tbl_masked[0][1], rf_tbl_masked[0][2]);
     if (ret) {
-        printk("rf config %x write fail: %d\n", rf_tbl_masked[0][0], ret);
+        AICWFDBG(LOGERROR, "rf config %x write fail: %d\n", rf_tbl_masked[0][0], ret);
     }
 }
 #endif

--- a/drivers/aic8800/aic8800_fdrv/rwnx_mod_params.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_mod_params.c
@@ -1658,7 +1658,7 @@ static void rwnx_set_wiphy_params(struct rwnx_hw *rwnx_hw, struct wiphy *wiphy)
         // function, that needs to be called after wiphy registration
         memcpy(country_code, default_ccode, sizeof(default_ccode));
 		regdomain = getRegdomainFromRwnxDB(wiphy, default_ccode);
-        printk(KERN_CRIT
+        AICWFDBG(LOGERROR,
                "\n\n%s: CAUTION: USING PERMISSIVE CUSTOM REGULATORY RULES\n\n",
                __func__);
         wiphy->regulatory_flags |= REGULATORY_CUSTOM_REG;
@@ -1667,7 +1667,7 @@ static void rwnx_set_wiphy_params(struct rwnx_hw *rwnx_hw, struct wiphy *wiphy)
 #elif (LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0))
         memcpy(country_code, default_ccode, sizeof(default_ccode));
 		regdomain = getRegdomainFromRwnxDB(wiphy, default_ccode);
-		printk(KERN_CRIT"%s: Registering custom regulatory\n", __func__);
+		AICWFDBG(LOGINFO, "%s: Registering custom regulatory\n", __func__);
 		wiphy->flags |= WIPHY_FLAG_CUSTOM_REGULATORY;
 		wiphy_apply_custom_regulatory(wiphy, regdomain);
 #endif

--- a/drivers/aic8800/aic8800_fdrv/rwnx_msg_tx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_msg_tx.c
@@ -4204,7 +4204,7 @@ int rwnx_send_mesh_start_req(struct rwnx_hw *rwnx_hw, struct rwnx_vif *vif,
 
         /* Check DMA mapping result */
         if (dma_mapping_error(rwnx_hw->dev, req->ie_addr)) {
-            printk(KERN_CRIT "%s - DMA Mapping error on additional IEs\n", __func__);
+            AICWFDBG(LOGERROR, "%s - DMA Mapping error on additional IEs\n", __func__);
 
             /* Consider there is no Additional IEs */
             req->ie_len = 0;

--- a/drivers/aic8800/aic_load_fw/aic_compat_8800d80.c
+++ b/drivers/aic8800/aic_load_fw/aic_compat_8800d80.c
@@ -309,6 +309,9 @@ int system_config_8800d80(struct aic_usb_dev *usb_dev){
 			AICWFDBG(LOGERROR, "%x rd fail: %d\n", mem_addr, ret);
 			return ret;
 		}
+        if (((rd_mem_addr_cfm.memdata >> 25) & 0x01UL) == 0x00UL) {
+            chip_mcu_id = 1;
+        }
 		chip_id = (u8)(rd_mem_addr_cfm.memdata >> 16);
 		AICWFDBG(LOGINFO, "chip_id=%x, chip_mcu_id = %d\n", chip_id, chip_mcu_id);
     #if 1


### PR DESCRIPTION
## Summary
- **Restore chip_mcu_id logic** in `aic_compat_8800d80.c` — the bit-25 check was accidentally removed during the printk-to-AICWFDBG conversion in PR #4, causing `chip_mcu_id` to always remain 0
- **Fix Makefile** `install_firmware` target — `@echo` inside a shell `if` block is a Make directive, not a shell command; replaced with `echo` and added `sudo mkdir -p`
- **Fix C89 declaration-after-statement** in `aic_br_ext.c` `scdb_findEntry` — moved AICWFDBG call after variable declarations
- **Fix `print_help` log level** in `aic_priv_cmd.c` — changed from LOGERROR to LOGINFO (help text is not an error)
- **Convert all remaining `printk`/`KERN_CRIT` calls** to `AICWFDBG()` across `rwnx_cmds.c`, `rwnx_cfgfile.c`, `rwnx_fw_dump.c`, `rwnx_msg_tx.c`, `rwnx_mod_params.c`, and `rwnx_main.c` (including the RWNX_PRINT_CFM_ERR macro and disabled #if 0 blocks)

## Test plan
- [ ] Verify `chip_mcu_id` is correctly assigned on 8800D80 hardware
- [ ] Run `make install_firmware` to confirm Makefile fix
- [ ] `grep -rn 'printk' drivers/aic8800/ --include='*.c' | grep -v 'AICWFDBG\|//\|/\*\|#define\|MODULE_\|TP_printk\|#include'` returns only commented-out references
- [ ] Build driver modules to verify no compilation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)