### PR TITLE
fix: add kernel 7.1+ cfg80211 API compatibility

### DIFF
--- a/drivers/aic8800/aic8800_fdrv/rwnx_compat.h
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_compat.h
@@ -459,4 +459,27 @@ typedef __s64 time64_t;
 #endif
 #endif
 
+/* KERNEL 7.1+ cfg80211 API changes */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+
+#define cfg80211_new_sta_call(wdev, mac_addr, sinfo, gfp) \
+    cfg80211_new_sta(wdev, mac_addr, sinfo, gfp)
+
+#define cfg80211_del_sta_call(wdev, mac_addr, gfp) \
+    cfg80211_del_sta(wdev, mac_addr, gfp)
+
+#define mgmt_action_field(mgmt, field) ((mgmt)->u.action.field)
+
+#else
+
+#define cfg80211_new_sta_call(ndev, mac_addr, sinfo, gfp) \
+    cfg80211_new_sta(ndev, mac_addr, sinfo, gfp)
+
+#define cfg80211_del_sta_call(ndev, mac_addr, gfp) \
+    cfg80211_del_sta(ndev, mac_addr, gfp)
+
+#define mgmt_action_field(mgmt, field) ((mgmt)->u.action.u.field)
+
+#endif
+
 #endif /* _RWNX_COMPAT_H_ */

--- a/drivers/aic8800/aic8800_fdrv/rwnx_compat.h
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_compat.h
@@ -470,6 +470,8 @@ typedef __s64 time64_t;
 
 #define mgmt_action_field(mgmt, field) ((mgmt)->u.action.field)
 
+#define mgmt_action_code(mgmt, field) ((mgmt)->u.action.action_code)
+
 #else
 
 #define cfg80211_new_sta_call(vif, mac_addr, sinfo, gfp) \
@@ -479,6 +481,8 @@ typedef __s64 time64_t;
     cfg80211_del_sta((vif)->ndev, mac_addr, gfp)
 
 #define mgmt_action_field(mgmt, field) ((mgmt)->u.action.u.field)
+
+#define mgmt_action_code(mgmt, field) ((mgmt)->u.action.u.field.action_code)
 
 #endif
 

--- a/drivers/aic8800/aic8800_fdrv/rwnx_compat.h
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_compat.h
@@ -462,21 +462,21 @@ typedef __s64 time64_t;
 /* KERNEL 7.1+ cfg80211 API changes */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
 
-#define cfg80211_new_sta_call(wdev, mac_addr, sinfo, gfp) \
-    cfg80211_new_sta(wdev, mac_addr, sinfo, gfp)
+#define cfg80211_new_sta_call(vif, mac_addr, sinfo, gfp) \
+    cfg80211_new_sta(&(vif)->wdev, mac_addr, sinfo, gfp)
 
-#define cfg80211_del_sta_call(wdev, mac_addr, gfp) \
-    cfg80211_del_sta(wdev, mac_addr, gfp)
+#define cfg80211_del_sta_call(vif, mac_addr, gfp) \
+    cfg80211_del_sta(&(vif)->wdev, mac_addr, gfp)
 
 #define mgmt_action_field(mgmt, field) ((mgmt)->u.action.field)
 
 #else
 
-#define cfg80211_new_sta_call(ndev, mac_addr, sinfo, gfp) \
-    cfg80211_new_sta(ndev, mac_addr, sinfo, gfp)
+#define cfg80211_new_sta_call(vif, mac_addr, sinfo, gfp) \
+    cfg80211_new_sta((vif)->ndev, mac_addr, sinfo, gfp)
 
-#define cfg80211_del_sta_call(ndev, mac_addr, gfp) \
-    cfg80211_del_sta(ndev, mac_addr, gfp)
+#define cfg80211_del_sta_call(vif, mac_addr, gfp) \
+    cfg80211_del_sta((vif)->ndev, mac_addr, gfp)
 
 #define mgmt_action_field(mgmt, field) ((mgmt)->u.action.u.field)
 

--- a/drivers/aic8800/aic8800_fdrv/rwnx_events.h
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_events.h
@@ -189,7 +189,7 @@ DECLARE_EVENT_CLASS(
         __entry->sta_idx = sta_idx;
         __entry->frame_control = mgmt->frame_control;
         __entry->action_cat = mgmt->u.action.category;
-        __entry->action_type = mgmt_action_field(mgmt, wme_action).action_code;
+        __entry->action_type = mgmt_action_code(mgmt, wme_action);
         __entry->action_p2p = *((u8 *)&mgmt->u.action.category
                                  + MGMT_ACTION_OUI_SUBTYPE_OFFSET);
                    ),

--- a/drivers/aic8800/aic8800_fdrv/rwnx_events.h
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_events.h
@@ -189,7 +189,7 @@ DECLARE_EVENT_CLASS(
         __entry->sta_idx = sta_idx;
         __entry->frame_control = mgmt->frame_control;
         __entry->action_cat = mgmt->u.action.category;
-        __entry->action_type = mgmt->u.action.u.wme_action.action_code;
+        __entry->action_type = mgmt_action_field(mgmt, wme_action).action_code;
         __entry->action_p2p = *((u8 *)&mgmt->u.action.category
                                  + MGMT_ACTION_OUI_SUBTYPE_OFFSET);
                    ),

--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -2833,22 +2833,14 @@ static int rwnx_cfg80211_del_key(struct wiphy *wiphy,
 /**
  * @set_default_key: set the default key on an interface
  */
-static int rwnx_cfg80211_set_default_key(struct wiphy *wiphy,
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
-                                         struct wireless_dev *wdev,
-#else
-                                         struct net_device *netdev,
-#endif
+ static int rwnx_cfg80211_set_default_key(struct wiphy *wiphy,
+                                          struct net_device *netdev,
 #if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION2)
-                                                                 int link_id,
+                                          int link_id,
 #endif
-                                         u8 key_index, bool unicast, bool multicast)
+                                          u8 key_index, bool unicast, bool multicast)
 {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
-    (void)wdev;
-#else
     (void)netdev;
-#endif
 #if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION2)
     (void)link_id;
 #endif

--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -2821,7 +2821,11 @@ static int rwnx_cfg80211_del_key(struct wiphy *wiphy,
  * @set_default_key: set the default key on an interface
  */
 static int rwnx_cfg80211_set_default_key(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+                                         struct wireless_dev *wdev,
+#else
                                          struct net_device *netdev,
+#endif
 #if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION2)
                                                                  int link_id,
 #endif
@@ -3163,7 +3167,7 @@ static int rwnx_cfg80211_add_station(struct wiphy *wiphy,
 	struct net_device *dev,
 #endif
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
-	const u8 *mac,
+	u8 *mac,
 #else
 	const u8 *mac,
 #endif
@@ -3265,7 +3269,7 @@ static int rwnx_cfg80211_add_station(struct wiphy *wiphy,
                 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0)
                 sinfo.filled |= STATION_INFO_ASSOC_REQ_IES;
                 #endif
-			cfg80211_new_sta_call(rwnx_vif->ndev, sta->mac_addr, &sinfo, GFP_KERNEL);
+			cfg80211_new_sta_call(rwnx_vif, sta->mac_addr, &sinfo, GFP_KERNEL);
             }
 
 #ifdef CONFIG_BAND_STEERING
@@ -3290,7 +3294,7 @@ static int rwnx_cfg80211_add_station(struct wiphy *wiphy,
             #define PRINT_STA_FLAG(f)                               \
                 (params->sta_flags_set & BIT(NL80211_STA_FLAG_##f) ? "["#f"]" : "")
 
-            netdev_info(dev, "Add sta %d (%pM) flags=%s%s%s%s%s%s%s",
+            netdev_info(rwnx_vif->ndev, "Add sta %d (%pM) flags=%s%s%s%s%s%s%s",
                         sta->sta_idx, mac,
                         PRINT_STA_FLAG(AUTHORIZED),
                         PRINT_STA_FLAG(SHORT_PREAMBLE),
@@ -3375,7 +3379,7 @@ static int rwnx_cfg80211_del_station_compat(struct wiphy *wiphy,
 		spin_unlock_bh(&rwnx_hw->cb_lock);
 
 		if(found) {
-			netdev_info(dev, "Del sta %d (%pM)", cur->sta_idx, cur->mac_addr);
+			netdev_info(rwnx_vif->ndev, "Del sta %d (%pM)", cur->sta_idx, cur->mac_addr);
 			if (cur->vif_idx != cur->vlan_idx) {
 				struct rwnx_vif *vlan_vif;
 				vlan_vif = rwnx_hw->vif_table[cur->vlan_idx];
@@ -3389,7 +3393,7 @@ static int rwnx_cfg80211_del_station_compat(struct wiphy *wiphy,
 				}
 			}
             		if (rwnx_vif->wdev.iftype == NL80211_IFTYPE_AP || rwnx_vif->wdev.iftype == NL80211_IFTYPE_P2P_GO) {
-                 		cfg80211_del_sta_call(rwnx_vif->ndev, cur->mac_addr, GFP_KERNEL);
+                 		cfg80211_del_sta_call(rwnx_vif, cur->mac_addr, GFP_KERNEL);
             		}
 
 #ifdef AICWF_RX_REORDER
@@ -3621,7 +3625,7 @@ static int rwnx_cfg80211_change_station(struct wiphy *wiphy,
 	struct net_device *dev,
 #endif
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
-	const u8 *mac,
+	u8 *mac,
 #else
 	const u8 *mac,
 #endif
@@ -3641,7 +3645,7 @@ static int rwnx_cfg80211_change_station(struct wiphy *wiphy,
         /* Add the TDLS station */
         if (params->sta_flags_set & BIT(NL80211_STA_FLAG_TDLS_PEER))
         {
-            struct rwnx_vif *rwnx_vif = netdev_priv(dev);
+            struct rwnx_vif *rwnx_vif = vif;
             struct me_sta_add_cfm me_sta_add_cfm;
             int error = 0;
 
@@ -3712,7 +3716,7 @@ static int rwnx_cfg80211_change_station(struct wiphy *wiphy,
                     #define PRINT_STA_FLAG(f)                               \
                         (params->sta_flags_set & BIT(NL80211_STA_FLAG_##f) ? "["#f"]" : "")
 
-                    netdev_info(dev, "Add %s TDLS sta %d (%pM) flags=%s%s%s%s%s%s%s",
+                    netdev_info(rwnx_vif->ndev, "Add %s TDLS sta %d (%pM) flags=%s%s%s%s%s%s%s",
                                 sta->tdls.initiator ? "initiator" : "responder",
                                 sta->sta_idx, mac,
                                 PRINT_STA_FLAG(AUTHORIZED),
@@ -5583,7 +5587,7 @@ static int rwnx_cfg80211_get_station(struct wiphy *wiphy,
 	struct net_device *dev,
 #endif
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
-	const u8 *mac,
+	u8 *mac,
 #else
 	const u8 *mac,
 #endif

--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -2762,6 +2762,17 @@ static int rwnx_cfg80211_get_key(struct wiphy *wiphy,
                                  void *cookie,
                                  void (*callback)(void *cookie, struct key_params*))
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+    (void)wdev;
+#else
+    (void)netdev;
+#endif
+    (void)link_id;
+    (void)key_index;
+    (void)pairwise;
+    (void)mac_addr;
+    (void)cookie;
+    (void)callback;
     RWNX_DBG(RWNX_FN_ENTRY_STR);
 
     return -1;
@@ -2831,6 +2842,11 @@ static int rwnx_cfg80211_set_default_key(struct wiphy *wiphy,
 #endif
                                          u8 key_index, bool unicast, bool multicast)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+    (void)wdev;
+#else
+    (void)netdev;
+#endif
     RWNX_DBG(RWNX_FN_ENTRY_STR);
 
     return 0;
@@ -2850,6 +2866,11 @@ static int rwnx_cfg80211_set_default_mgmt_key(struct wiphy *wiphy,
 #endif
                                               u8 key_index)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+    (void)wdev;
+#else
+    (void)netdev;
+#endif
     return 0;
 }
 

--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -2644,15 +2644,24 @@ bool key_flag = false;
  * @add_key: add a key with the given parameters. @mac_addr will be %NULL
  *	when adding a group key.
  */
-static int rwnx_cfg80211_add_key(struct wiphy *wiphy, struct net_device *netdev,
+static int rwnx_cfg80211_add_key(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+                                 struct wireless_dev *wdev,
+#else
+                                 struct net_device *netdev,
+#endif
 #if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION2)
-                                                                 int link_id,
+                                 int link_id,
 #endif
                                  u8 key_index, bool pairwise, const u8 *mac_addr,
                                  struct key_params *params)
 {
     struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+    struct rwnx_vif *vif = container_of(wdev, struct rwnx_vif, wdev);
+#else
     struct rwnx_vif *vif = netdev_priv(netdev);
+#endif
     int i, error = 0;
     struct mm_key_add_cfm key_add_cfm;
     u8_l cipher = 0;
@@ -2740,11 +2749,15 @@ static int rwnx_cfg80211_add_key(struct wiphy *wiphy, struct net_device *netdev,
  *	not possible to retrieve the key, -ENOENT if it doesn't exist.
  *
  */
-static int rwnx_cfg80211_get_key(struct wiphy *wiphy, struct net_device *netdev,
-#if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION2)
-                                                                 int link_id,
+static int rwnx_cfg80211_get_key(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+                                 struct wireless_dev *wdev,
+#else
+                                 struct net_device *netdev,
 #endif
-
+#if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION2)
+                                 int link_id,
+#endif
                                  u8 key_index, bool pairwise, const u8 *mac_addr,
                                  void *cookie,
                                  void (*callback)(void *cookie, struct key_params*))
@@ -2759,15 +2772,23 @@ static int rwnx_cfg80211_get_key(struct wiphy *wiphy, struct net_device *netdev,
  * @del_key: remove a key given the @mac_addr (%NULL for a group key)
  *	and @key_index, return -ENOENT if the key doesn't exist.
  */
-static int rwnx_cfg80211_del_key(struct wiphy *wiphy, struct net_device *netdev,
-#if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION2)
-                                                                 int link_id,
+static int rwnx_cfg80211_del_key(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+                                 struct wireless_dev *wdev,
+#else
+                                 struct net_device *netdev,
 #endif
-
+#if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION2)
+                                 int link_id,
+#endif
                                  u8 key_index, bool pairwise, const u8 *mac_addr)
 {
     struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+    struct rwnx_vif *vif = container_of(wdev, struct rwnx_vif, wdev);
+#else
     struct rwnx_vif *vif = netdev_priv(netdev);
+#endif
     int error;
     struct rwnx_sta *sta = NULL;
     struct rwnx_key *rwnx_key;
@@ -2815,9 +2836,13 @@ static int rwnx_cfg80211_set_default_key(struct wiphy *wiphy,
  * @set_default_mgmt_key: set the default management frame key on an interface
  */
 static int rwnx_cfg80211_set_default_mgmt_key(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+                                              struct wireless_dev *wdev,
+#else
                                               struct net_device *netdev,
+#endif
 #if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION2)
-                                                                 int link_id,
+                                              int link_id,
 #endif
                                               u8 key_index)
 {
@@ -3132,16 +3157,24 @@ static int rwnx_cfg80211_external_auth(struct wiphy *wiphy, struct net_device *d
  * @add_station: Add a new station.
  */
 static int rwnx_cfg80211_add_station(struct wiphy *wiphy,
-	struct net_device *dev,
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
-		u8 *mac,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct wireless_dev *wdev,
 #else
-		const u8 *mac,
+	struct net_device *dev,
+#endif
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
+	const u8 *mac,
+#else
+	const u8 *mac,
 #endif
 	struct station_parameters *params)
 {
     struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+    struct rwnx_vif *rwnx_vif = container_of(wdev, struct rwnx_vif, wdev);
+#else
     struct rwnx_vif *rwnx_vif = netdev_priv(dev);
+#endif
     struct me_sta_add_cfm me_sta_add_cfm;
     int error = 0;
 
@@ -3232,7 +3265,7 @@ static int rwnx_cfg80211_add_station(struct wiphy *wiphy,
                 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0)
                 sinfo.filled |= STATION_INFO_ASSOC_REQ_IES;
                 #endif
-		        cfg80211_new_sta(rwnx_vif->ndev, sta->mac_addr, &sinfo, GFP_KERNEL);
+			cfg80211_new_sta_call(rwnx_vif->ndev, sta->mac_addr, &sinfo, GFP_KERNEL);
             }
 
 #ifdef CONFIG_BAND_STEERING
@@ -3283,7 +3316,11 @@ static int rwnx_cfg80211_add_station(struct wiphy *wiphy,
  * @del_station: Remove a station
  */
 static int rwnx_cfg80211_del_station_compat(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+                                            struct wireless_dev *wdev,
+#else
                                             struct net_device *dev,
+#endif
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 		u8 *mac
 #elif (LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0))
@@ -3294,7 +3331,11 @@ static int rwnx_cfg80211_del_station_compat(struct wiphy *wiphy,
 )
 {
     struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+    struct rwnx_vif *rwnx_vif = container_of(wdev, struct rwnx_vif, wdev);
+#else
     struct rwnx_vif *rwnx_vif = netdev_priv(dev);
+#endif
     struct rwnx_sta *cur, *tmp;
     int error = 0, found = 0;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)
@@ -3348,7 +3389,7 @@ static int rwnx_cfg80211_del_station_compat(struct wiphy *wiphy,
 				}
 			}
             		if (rwnx_vif->wdev.iftype == NL80211_IFTYPE_AP || rwnx_vif->wdev.iftype == NL80211_IFTYPE_P2P_GO) {
-                		cfg80211_del_sta(rwnx_vif->ndev, cur->mac_addr, GFP_KERNEL);
+                 		cfg80211_del_sta_call(rwnx_vif->ndev, cur->mac_addr, GFP_KERNEL);
             		}
 
 #ifdef AICWF_RX_REORDER
@@ -3573,16 +3614,25 @@ static void apm_probe_sta_work_process(struct work_struct *work)
  *	them, also against the existing state! Drivers must call
  *	cfg80211_check_station_change() to validate the information.
  */
-static int rwnx_cfg80211_change_station(struct wiphy *wiphy, struct net_device *dev,
+static int rwnx_cfg80211_change_station(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct wireless_dev *wdev,
+#else
+	struct net_device *dev,
+#endif
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
-	u8 *mac,
+	const u8 *mac,
 #else
 	const u8 *mac,
 #endif
 	struct station_parameters *params)
 {
     struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+    struct rwnx_vif *vif = container_of(wdev, struct rwnx_vif, wdev);
+#else
     struct rwnx_vif *vif = netdev_priv(dev);
+#endif
     struct rwnx_sta *sta;
 
     sta = rwnx_get_sta(rwnx_hw, mac);
@@ -5527,15 +5577,23 @@ int rwnx_fill_station_info(struct rwnx_sta *sta, struct rwnx_vif *vif,
  * @get_station: get station information for the station identified by @mac
  */
 static int rwnx_cfg80211_get_station(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct wireless_dev *wdev,
+#else
 	struct net_device *dev,
+#endif
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
-	u8 *mac,
+	const u8 *mac,
 #else
 	const u8 *mac,
 #endif
 	struct station_info *sinfo)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+    struct rwnx_vif *vif = container_of(wdev, struct rwnx_vif, wdev);
+#else
     struct rwnx_vif *vif = netdev_priv(dev);
+#endif
     struct rwnx_sta *sta = NULL;
 
     if (RWNX_VIF_TYPE(vif) == NL80211_IFTYPE_MONITOR)
@@ -5568,10 +5626,19 @@ static int rwnx_cfg80211_get_station(struct wiphy *wiphy,
 /**
  * @dump_station: dump station callback -- resume dump at index @idx
  */
-static int rwnx_cfg80211_dump_station(struct wiphy *wiphy, struct net_device *dev,
+static int rwnx_cfg80211_dump_station(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+                                      struct wireless_dev *wdev,
+#else
+                                      struct net_device *dev,
+#endif
                                       int idx, u8 *mac, struct station_info *sinfo)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+    struct rwnx_vif *rwnx_vif = container_of(wdev, struct rwnx_vif, wdev);
+#else
     struct rwnx_vif *rwnx_vif = netdev_priv(dev);
+#endif
     //struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
     struct rwnx_sta *sta_iter, *sta = NULL;
     //struct mesh_peer_info_cfm peer_info_cfm;

--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -2934,7 +2934,12 @@ static int rwnx_cfg80211_connect(struct wiphy *wiphy, struct net_device *dev,
         key_params.key_len = sme->key_len;
         key_params.seq_len = 0;
         key_params.cipher = sme->crypto.cipher_group;
-        rwnx_cfg80211_add_key(wiphy, dev,
+        rwnx_cfg80211_add_key(wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+                                &rwnx_vif->wdev,
+#else
+                                dev,
+#endif
 #if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION2)
                                 0,
 #endif
@@ -3996,7 +4001,13 @@ static int rwnx_cfg80211_stop_ap(struct wiphy *wiphy, struct net_device *dev)
 
     /* delete any remaining STA*/
     while (!list_empty(&rwnx_vif->ap.sta_list)) {
-        rwnx_cfg80211_del_station_compat(wiphy, dev, NULL);
+        rwnx_cfg80211_del_station_compat(wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+                                          &rwnx_vif->wdev,
+#else
+                                          dev,
+#endif
+                                          NULL);
     }
 
 #ifdef CONFIG_BAND_STEERING

--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -2767,7 +2767,9 @@ static int rwnx_cfg80211_get_key(struct wiphy *wiphy,
 #else
     (void)netdev;
 #endif
+#if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION2)
     (void)link_id;
+#endif
     (void)key_index;
     (void)pairwise;
     (void)mac_addr;
@@ -2847,6 +2849,12 @@ static int rwnx_cfg80211_set_default_key(struct wiphy *wiphy,
 #else
     (void)netdev;
 #endif
+#if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION2)
+    (void)link_id;
+#endif
+    (void)key_index;
+    (void)unicast;
+    (void)multicast;
     RWNX_DBG(RWNX_FN_ENTRY_STR);
 
     return 0;
@@ -2871,6 +2879,10 @@ static int rwnx_cfg80211_set_default_mgmt_key(struct wiphy *wiphy,
 #else
     (void)netdev;
 #endif
+#if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION2)
+    (void)link_id;
+#endif
+    (void)key_index;
     return 0;
 }
 

--- a/drivers/aic8800/aic8800_fdrv/rwnx_tdls.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_tdls.c
@@ -115,9 +115,15 @@ rwnx_prep_tdls_direct(struct rwnx_hw *rwnx_hw, struct rwnx_vif *rwnx_vif,
 
     switch (action_code) {
     case WLAN_PUB_ACTION_TDLS_DISCOVER_RES:
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+        /* action_code moved out of the per-category union on 7.1+, so the
+         * fixed action-frame header is category + action_code + variant. */
+        skb_put(skb, 2 + sizeof(mgmt_action_field(mgmt, tdls_discover_resp)));
+#else
         skb_put(skb, 1 + sizeof(mgmt_action_field(mgmt, tdls_discover_resp)));
+#endif
         mgmt->u.action.category = WLAN_CATEGORY_PUBLIC;
-        mgmt_action_field(mgmt, tdls_discover_resp).action_code = WLAN_PUB_ACTION_TDLS_DISCOVER_RES;
+        mgmt_action_code(mgmt, tdls_discover_resp) = WLAN_PUB_ACTION_TDLS_DISCOVER_RES;
         mgmt_action_field(mgmt, tdls_discover_resp).dialog_token = dialog_token;
         mgmt_action_field(mgmt, tdls_discover_resp).capability =
             cpu_to_le16(rwnx_get_tdls_sta_capab(rwnx_vif, status_code));

--- a/drivers/aic8800/aic8800_fdrv/rwnx_tdls.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_tdls.c
@@ -115,11 +115,11 @@ rwnx_prep_tdls_direct(struct rwnx_hw *rwnx_hw, struct rwnx_vif *rwnx_vif,
 
     switch (action_code) {
     case WLAN_PUB_ACTION_TDLS_DISCOVER_RES:
-        skb_put(skb, 1 + sizeof(mgmt->u.action.u.tdls_discover_resp));
+        skb_put(skb, 1 + sizeof(mgmt_action_field(mgmt, tdls_discover_resp)));
         mgmt->u.action.category = WLAN_CATEGORY_PUBLIC;
-        mgmt->u.action.u.tdls_discover_resp.action_code = WLAN_PUB_ACTION_TDLS_DISCOVER_RES;
-        mgmt->u.action.u.tdls_discover_resp.dialog_token = dialog_token;
-        mgmt->u.action.u.tdls_discover_resp.capability =
+        mgmt_action_field(mgmt, tdls_discover_resp).action_code = WLAN_PUB_ACTION_TDLS_DISCOVER_RES;
+        mgmt_action_field(mgmt, tdls_discover_resp).dialog_token = dialog_token;
+        mgmt_action_field(mgmt, tdls_discover_resp).capability =
             cpu_to_le16(rwnx_get_tdls_sta_capab(rwnx_vif, status_code));
         break;
     default:


### PR DESCRIPTION
### Problem

The driver fails to build against Linux kernel 7.1+ with 16 compilation errors. The kernel cfg80211 API changed in two breaking ways:

1. **`cfg80211_ops` callback signatures changed** — all station/key management callbacks now take `struct wireless_dev *wdev` instead of `struct net_device *netdev`
2. **`struct ieee80211_mgmt` union was flattened** — `mgmt->u.action.u.tdls_*` became `mgmt->u.action.tdls_*`

### Changes

- **`rwnx_compat.h`**: Added `KERNEL_VERSION(7, 1, 0)` guards with compat macros for `cfg80211_new_sta_call`, `cfg80211_del_sta_call`, and `mgmt_action_field`
- **`rwnx_main.c`**: Updated 9 callback function signatures (`add_key`, `get_key`, `del_key`, `set_default_mgmt_key`, `add_station`, `del_station_compat`, `change_station`, `get_station`, `dump_station`) to accept `struct wireless_dev *wdev` for kernel ≥ 7.1, derived `rwnx_vif` via `container_of()`
- **`rwnx_tdls.c`**: Updated `mgmt->u.action.u.*` → `mgmt_action_field(mgmt, *)` for kernel ≥ 7.1
- **`rwnx_events.h`**: Same `mgmt_action_field()` macro for tracepoint

### Build verified

- ✅ Builds on kernel 6.18.38-2-cachyos-lts (current system)
- Should fix kernel 7.1.3-2-cachyos (reported issue)

### Related

Fixes #11