### PR TITLE
fix: support kernel 7.2+ build (clang implicit declarations, remain_on_channel signature)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,58 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build against ${{ matrix.headers }}
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:base-devel
+    strategy:
+      # Report every kernel independently - a break on one is not a reason to
+      # hide the result for the other.
+      fail-fast: false
+      matrix:
+        headers:
+          - linux-headers
+          - linux-lts-headers
+    steps:
+      - name: Install toolchain and kernel headers
+        run: |
+          pacman -Syu --noconfirm --needed git bc cpio ${{ matrix.headers }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve kernel build directory
+        id: kernel
+        run: |
+          # uname -r inside the container reports the runner's host kernel, not
+          # the headers we just installed, so KDIR has to be resolved explicitly.
+          KDIR=$(ls -d /usr/lib/modules/*/build 2>/dev/null | head -1)
+          if [ -z "$KDIR" ]; then
+            echo "ERROR: no kernel build directory found for ${{ matrix.headers }}"
+            exit 1
+          fi
+          KVER=$(basename "$(dirname "$KDIR")")
+          echo "kdir=${KDIR}" >> "$GITHUB_OUTPUT"
+          echo "kver=${KVER}" >> "$GITHUB_OUTPUT"
+          echo "Building against kernel ${KVER} (${KDIR})"
+
+      - name: Build modules
+        run: |
+          make -C drivers/aic8800 KDIR='${{ steps.kernel.outputs.kdir }}' modules
+
+      - name: Verify modules were produced
+        run: |
+          FOUND=$(find drivers/aic8800 -name '*.ko' -printf '%p\n' | sort)
+          if [ -z "$FOUND" ]; then
+            echo "ERROR: build reported success but produced no .ko files"
+            exit 1
+          fi
+          echo "Built against kernel ${{ steps.kernel.outputs.kver }}:"
+          echo "$FOUND"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,6 +188,36 @@ jobs:
             echo "::notice title=Unused label::upstream ${{ matrix.tag }}: no -Wunused-label warnings"
           fi
 
+      # Survey only: reports whether the driver could be built with upstream's
+      # default CONFIG_WERROR=y. Never fails the job.
+      - name: Probe whether CONFIG_WERROR would pass
+        continue-on-error: true
+        run: |
+          cd linux
+          scripts/config --enable WERROR
+          make -s -j"$(nproc)" olddefconfig
+          make -s -j"$(nproc)" modules_prepare
+          cd ..
+          make -C driver/drivers/aic8800 \
+            KDIR='${{ steps.kernel.outputs.kdir }}' clean >/dev/null 2>&1 || true
+          # -k keeps going so every -Werror site is enumerated, not just the first.
+          if make -k -C driver/drivers/aic8800 \
+               KDIR='${{ steps.kernel.outputs.kdir }}' \
+               KBUILD_MODPOST_WARN=1 modules > /tmp/werror.log 2>&1; then
+            echo "::notice title=CONFIG_WERROR probe::clean - CONFIG_WERROR could be enabled for upstream ${{ matrix.tag }}"
+            exit 0
+          fi
+          TOTAL=$(grep -c 'error:' /tmp/werror.log || true)
+          echo "::warning title=CONFIG_WERROR probe::not clean - ${TOTAL} error line(s) with CONFIG_WERROR=y"
+          grep -oE '\[-Werror=[A-Za-z0-9=-]+\]' /tmp/werror.log | sort | uniq -c | sort -rn \
+            | while read -r count flag; do
+                echo "::warning title=Werror flag::${count}x ${flag}"
+              done
+          grep 'error:' /tmp/werror.log | sed 's|^.*/drivers/|drivers/|' | sort -u | head -n 20 \
+            | while IFS= read -r line; do
+                echo "::warning title=Werror site::${line}"
+              done
+
       - name: Report kernel coverage
         run: |
           echo "::notice title=Kernel coverage::upstream ${{ matrix.tag }} = ${{ steps.kernel.outputs.kver }}: exercises the >= 7.2 code path"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,8 +138,14 @@ jobs:
       - name: Build modules
         run: |
           set -o pipefail
+          # modules_prepare does not build the kernel, so there is no kernel
+          # Module.symvers and modpost cannot resolve external symbols.
+          # KBUILD_MODPOST_WARN downgrades that to warnings. Compilation is what
+          # proves API compatibility here: a cfg80211_ops signature mismatch is
+          # a hard compile error long before modpost runs.
           if ! make -C driver/drivers/aic8800 \
-                 KDIR='${{ steps.kernel.outputs.kdir }}' modules 2>&1 | tee /tmp/build.log; then
+                 KDIR='${{ steps.kernel.outputs.kdir }}' \
+                 KBUILD_MODPOST_WARN=1 modules 2>&1 | tee /tmp/build.log; then
             # Promote compiler diagnostics to annotations so a failure is
             # diagnosable from the checks API without opening the raw log.
             grep -E 'error:|Error [0-9]+' /tmp/build.log | head -n 25 | while IFS= read -r line; do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,19 +105,32 @@ jobs:
   # so the jobs above cannot compile the >= 7.2 code paths at all. Prepare an
   # upstream tree instead - that is the only way to prove the 7.2 claim.
   build-upstream:
-    name: Build against upstream ${{ matrix.tag }}
+    name: Build against upstream ${{ matrix.tag }} (${{ matrix.compiler }})
     runs-on: ubuntu-latest
     container:
       image: archlinux:base-devel
     strategy:
       fail-fast: false
       matrix:
-        tag:
-          - v7.2
+        include:
+          - tag: v7.2
+            compiler: gcc
+            llvm: ''
+          # gcc-only matrix misses clang-only errors. CONFIG_CC_IS_CLANG is
+          # def_bool $(success,...) in init/Kconfig - not settable via
+          # scripts/config, so the tree must be built with LLVM=1.
+          - tag: v7.2
+            compiler: clang
+            llvm: 'LLVM=1'
     steps:
       - name: Install toolchain
         run: |
           pacman -Syu --noconfirm --needed git bc cpio elfutils flex bison openssl perl python
+
+      - name: Install LLVM toolchain
+        if: matrix.compiler == 'clang'
+        run: |
+          pacman -S --noconfirm --needed clang llvm lld
 
       - name: Checkout driver
         uses: actions/checkout@v4
@@ -130,27 +143,39 @@ jobs:
           git clone --depth 1 --branch '${{ matrix.tag }}' \
             https://github.com/torvalds/linux.git linux
           cd linux
-          make -s -j"$(nproc)" defconfig
+          make -s -j"$(nproc)" ${{ matrix.llvm }} defconfig
           # modules_prepare only builds scripts and headers, so there is no
           # Module.symvers; MODVERSIONS would then reject the out-of-tree build.
           # CONFIG_WERROR is left at upstream's default (y) on purpose: the
           # driver is clean under it, so any newly introduced warning fails here
           # instead of silently accumulating.
+          #
+          # IPW2200 only to select CONFIG_WIRELESS_EXT: promptless bool, and
+          # CFG80211_WEXT selects WEXT_CORE not WIRELESS_EXT. Without it
+          # aic8800_fdrv/Makefile disables CONFIG_USE_WIRELESS_EXT.
           scripts/config --disable MODVERSIONS \
                          --disable MODULE_SIG \
                          --disable DEBUG_INFO_BTF \
                          --enable MODULES \
+                         --enable WLAN \
                          --module CFG80211 \
-                         --module MAC80211
-          make -s -j"$(nproc)" olddefconfig
-          # Assert the strictness this job depends on, so a future defconfig
-          # change cannot silently turn the strict build into a permissive one.
+                         --module MAC80211 \
+                         --module IPW2200
+          make -s -j"$(nproc)" ${{ matrix.llvm }} olddefconfig
           if ! grep -q '^CONFIG_WERROR=y' .config; then
             echo "ERROR: CONFIG_WERROR is not enabled - a green build here would prove nothing"
             exit 1
           fi
-          make -s -j"$(nproc)" modules_prepare
-          KVER=$(make -s kernelrelease)
+          if ! grep -q '^CONFIG_WIRELESS_EXT=y' .config; then
+            echo "ERROR: CONFIG_WIRELESS_EXT is not enabled - the wireless-extensions path would not be compiled"
+            exit 1
+          fi
+          if [ '${{ matrix.compiler }}' = clang ] && ! grep -q '^CONFIG_CC_IS_CLANG=y' .config; then
+            echo "ERROR: kernel tree was not built with clang - the driver build would fall back to gcc"
+            exit 1
+          fi
+          make -s -j"$(nproc)" ${{ matrix.llvm }} modules_prepare
+          KVER=$(make -s ${{ matrix.llvm }} kernelrelease)
           echo "kdir=${PWD}" >> "$GITHUB_OUTPUT"
           echo "kver=${KVER}" >> "$GITHUB_OUTPUT"
           echo "Prepared kernel ${KVER}"
@@ -181,18 +206,23 @@ jobs:
             exit 1
           fi
           echo "$FOUND"
+          if [ ! -f driver/drivers/aic8800/aic8800_fdrv/aicwf_wext_linux.o ]; then
+            echo "ERROR: aicwf_wext_linux.o was not built - the wireless-extensions path is not covered"
+            exit 1
+          fi
 
       - name: Check for unused-label warnings
         run: |
           # Annotation rather than a build failure - see the build job for why.
+          LABEL='upstream ${{ matrix.tag }} (${{ matrix.compiler }})'
           N=$(grep -c 'unused-label' /tmp/build.log || true)
           if [ "$N" -gt 0 ]; then
-            echo "::warning title=Unused label::upstream ${{ matrix.tag }}: ${N} -Wunused-label warning(s)"
+            echo "::warning title=Unused label::${LABEL}: ${N} -Wunused-label warning(s)"
             grep 'unused-label' /tmp/build.log | head -n 5
           else
-            echo "::notice title=Unused label::upstream ${{ matrix.tag }}: no -Wunused-label warnings"
+            echo "::notice title=Unused label::${LABEL}: no -Wunused-label warnings"
           fi
 
       - name: Report kernel coverage
         run: |
-          echo "::notice title=Kernel coverage::upstream ${{ matrix.tag }} = ${{ steps.kernel.outputs.kver }}: exercises the >= 7.2 code path"
+          echo "::notice title=Kernel coverage::upstream ${{ matrix.tag }} = ${{ steps.kernel.outputs.kver }}, ${{ matrix.compiler }}, WIRELESS_EXT=y: exercises the >= 7.2 code path"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,10 +136,12 @@ jobs:
           make -s -j"$(nproc)" defconfig
           # modules_prepare only builds scripts and headers, so there is no
           # Module.symvers; MODVERSIONS would then reject the out-of-tree build.
+          # CONFIG_WERROR is left at upstream's default (y) on purpose: the
+          # driver is clean under it, so any newly introduced warning fails here
+          # instead of silently accumulating.
           scripts/config --disable MODVERSIONS \
                          --disable MODULE_SIG \
                          --disable DEBUG_INFO_BTF \
-                         --disable WERROR \
                          --enable MODULES \
                          --module CFG80211 \
                          --module MAC80211
@@ -187,36 +189,6 @@ jobs:
           else
             echo "::notice title=Unused label::upstream ${{ matrix.tag }}: no -Wunused-label warnings"
           fi
-
-      # Survey only: reports whether the driver could be built with upstream's
-      # default CONFIG_WERROR=y. Never fails the job.
-      - name: Probe whether CONFIG_WERROR would pass
-        continue-on-error: true
-        run: |
-          cd linux
-          scripts/config --enable WERROR
-          make -s -j"$(nproc)" olddefconfig
-          make -s -j"$(nproc)" modules_prepare
-          cd ..
-          make -C driver/drivers/aic8800 \
-            KDIR='${{ steps.kernel.outputs.kdir }}' clean >/dev/null 2>&1 || true
-          # -k keeps going so every -Werror site is enumerated, not just the first.
-          if make -k -C driver/drivers/aic8800 \
-               KDIR='${{ steps.kernel.outputs.kdir }}' \
-               KBUILD_MODPOST_WARN=1 modules > /tmp/werror.log 2>&1; then
-            echo "::notice title=CONFIG_WERROR probe::clean - CONFIG_WERROR could be enabled for upstream ${{ matrix.tag }}"
-            exit 0
-          fi
-          TOTAL=$(grep -c 'error:' /tmp/werror.log || true)
-          echo "::warning title=CONFIG_WERROR probe::not clean - ${TOTAL} error line(s) with CONFIG_WERROR=y"
-          grep -oE '\[-Werror=[A-Za-z0-9=-]+\]' /tmp/werror.log | sort | uniq -c | sort -rn \
-            | while read -r count flag; do
-                echo "::warning title=Werror flag::${count}x ${flag}"
-              done
-          grep 'error:' /tmp/werror.log | sed 's|^.*/drivers/|drivers/|' | sort -u | head -n 20 \
-            | while IFS= read -r line; do
-                echo "::warning title=Werror site::${line}"
-              done
 
       - name: Report kernel coverage
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,7 @@ jobs:
           scripts/config --disable MODVERSIONS \
                          --disable MODULE_SIG \
                          --disable DEBUG_INFO_BTF \
+                         --disable WERROR \
                          --enable MODULES \
                          --module CFG80211 \
                          --module MAC80211

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,6 +146,12 @@ jobs:
                          --module CFG80211 \
                          --module MAC80211
           make -s -j"$(nproc)" olddefconfig
+          # Assert the strictness this job depends on, so a future defconfig
+          # change cannot silently turn the strict build into a permissive one.
+          if ! grep -q '^CONFIG_WERROR=y' .config; then
+            echo "ERROR: CONFIG_WERROR is not enabled - a green build here would prove nothing"
+            exit 1
+          fi
           make -s -j"$(nproc)" modules_prepare
           KVER=$(make -s kernelrelease)
           echo "kdir=${PWD}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,22 @@ jobs:
 
       - name: Build modules
         run: |
-          make -C drivers/aic8800 KDIR='${{ steps.kernel.outputs.kdir }}' modules
+          set -o pipefail
+          make -C drivers/aic8800 KDIR='${{ steps.kernel.outputs.kdir }}' modules 2>&1 \
+            | tee /tmp/build.log
+
+      - name: Check for unused-label warnings
+        run: |
+          # Kernel builds enable -Wall, so -Wunused-label shows up here without
+          # CONFIG_WERROR. Reported as an annotation rather than failing the
+          # build, so pre-existing vendor warnings cannot block unrelated PRs.
+          N=$(grep -c 'unused-label' /tmp/build.log || true)
+          if [ "$N" -gt 0 ]; then
+            echo "::warning title=Unused label::${{ matrix.label }}: ${N} -Wunused-label warning(s)"
+            grep 'unused-label' /tmp/build.log | head -n 5
+          else
+            echo "::notice title=Unused label::${{ matrix.label }}: no -Wunused-label warnings"
+          fi
 
       - name: Verify modules were produced
         run: |
@@ -162,6 +177,16 @@ jobs:
             exit 1
           fi
           echo "$FOUND"
+
+      - name: Check for unused-label warnings
+        run: |
+          N=$(grep -c 'unused-label' /tmp/build.log || true)
+          if [ "$N" -gt 0 ]; then
+            echo "::warning title=Unused label::upstream ${{ matrix.tag }}: ${N} -Wunused-label warning(s)"
+            grep 'unused-label' /tmp/build.log | head -n 5
+          else
+            echo "::notice title=Unused label::upstream ${{ matrix.tag }}: no -Wunused-label warnings"
+          fi
 
       - name: Report kernel coverage
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Build against ${{ matrix.headers }}
+    name: Build against ${{ matrix.label }}
     runs-on: ubuntu-latest
     container:
       image: archlinux:base-devel
@@ -17,13 +17,31 @@ jobs:
       # hide the result for the other.
       fail-fast: false
       matrix:
-        headers:
-          - linux-headers
-          - linux-lts-headers
+        include:
+          - label: linux-headers
+            package: linux-headers
+            testing: false
+          - label: linux-lts-headers
+            package: linux-lts-headers
+            testing: false
+          # Arch stable trails the newest kernel, so the stable jobs above cannot
+          # exercise the newest version-guarded code paths. The testing repos
+          # carry the next kernel; "Report kernel coverage" below states which
+          # version each job actually compiled against.
+          - label: linux-headers (testing)
+            package: linux-headers
+            testing: true
     steps:
+      - name: Enable Arch testing repositories
+        if: matrix.testing
+        run: |
+          # Must precede [core]/[extra] in pacman.conf to take precedence.
+          sed -i '/^\[core\]/i [core-testing]\nInclude = /etc/pacman.d/mirrorlist\n\n[extra-testing]\nInclude = /etc/pacman.d/mirrorlist\n' /etc/pacman.conf
+
       - name: Install toolchain and kernel headers
         run: |
-          pacman -Syu --noconfirm --needed git bc cpio ${{ matrix.headers }}
+          pacman -Sy --noconfirm
+          pacman -S --noconfirm --needed git bc cpio ${{ matrix.package }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,7 +53,7 @@ jobs:
           # the headers we just installed, so KDIR has to be resolved explicitly.
           KDIR=$(ls -d /usr/lib/modules/*/build 2>/dev/null | head -1)
           if [ -z "$KDIR" ]; then
-            echo "ERROR: no kernel build directory found for ${{ matrix.headers }}"
+            echo "ERROR: no kernel build directory found for ${{ matrix.package }}"
             exit 1
           fi
           KVER=$(basename "$(dirname "$KDIR")")
@@ -66,7 +84,7 @@ jobs:
           REST=${KVER#*.}
           MIN=${REST%%.*}
           if [ "$MAJ" -gt 7 ] || { [ "$MAJ" -eq 7 ] && [ "$MIN" -ge 2 ]; }; then
-            echo "::notice title=Kernel coverage::${{ matrix.headers }} = ${KVER}: exercises the >= 7.2 code path"
+            echo "::notice title=Kernel coverage::${{ matrix.label }} = ${KVER}: exercises the >= 7.2 code path"
           else
-            echo "::warning title=Kernel coverage::${{ matrix.headers }} = ${KVER}: below 7.2, so the >= 7.2 code path was NOT compiled by this job"
+            echo "::warning title=Kernel coverage::${{ matrix.label }} = ${KVER}: below 7.2, so the >= 7.2 code path was NOT compiled by this job"
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,7 @@ jobs:
 
       - name: Install toolchain and kernel headers
         run: |
-          pacman -Sy --noconfirm
-          pacman -S --noconfirm --needed git bc cpio ${{ matrix.package }}
+          pacman -Sy --noconfirm --needed git bc cpio ${{ matrix.package }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -64,8 +63,8 @@ jobs:
       - name: Build modules
         run: |
           set -o pipefail
-          make -C drivers/aic8800 KDIR='${{ steps.kernel.outputs.kdir }}' modules 2>&1 \
-            | tee /tmp/build.log
+          make -j"$(nproc)" -Otarget -C drivers/aic8800 \
+            KDIR='${{ steps.kernel.outputs.kdir }}' modules 2>&1 | tee /tmp/build.log
 
       - name: Check for unused-label warnings
         run: |
@@ -82,7 +81,7 @@ jobs:
 
       - name: Verify modules were produced
         run: |
-          FOUND=$(find drivers/aic8800 -name '*.ko' -printf '%p\n' | sort)
+          FOUND=$(find drivers/aic8800 -name '*.ko' | sort)
           if [ -z "$FOUND" ]; then
             echo "ERROR: build reported success but produced no .ko files"
             exit 1
@@ -95,13 +94,11 @@ jobs:
           # Surfaced as an annotation, not just log output, so which kernel was
           # actually compiled against is visible without digging into the logs.
           KVER='${{ steps.kernel.outputs.kver }}'
-          MAJ=${KVER%%.*}
-          REST=${KVER#*.}
-          MIN=${REST%%.*}
+          IFS='.-' read -r MAJ MIN _ <<<"$KVER"
           if [ "$MAJ" -gt 7 ] || { [ "$MAJ" -eq 7 ] && [ "$MIN" -ge 2 ]; }; then
             echo "::notice title=Kernel coverage::${{ matrix.label }} = ${KVER}: exercises the >= 7.2 code path"
           else
-            echo "::warning title=Kernel coverage::${{ matrix.label }} = ${KVER}: below 7.2, so the >= 7.2 code path was NOT compiled by this job"
+            echo "::notice title=Kernel coverage::${{ matrix.label }} = ${KVER}: below 7.2, so the >= 7.2 path is covered by the upstream job instead"
           fi
 
   # Arch does not package kernel 7.2 yet, not even in the testing repositories,
@@ -166,20 +163,19 @@ jobs:
           # KBUILD_MODPOST_WARN downgrades that to warnings. Compilation is what
           # proves API compatibility here: a cfg80211_ops signature mismatch is
           # a hard compile error long before modpost runs.
-          if ! make -C driver/drivers/aic8800 \
+          if ! make -j"$(nproc)" -Otarget -C driver/drivers/aic8800 \
                  KDIR='${{ steps.kernel.outputs.kdir }}' \
                  KBUILD_MODPOST_WARN=1 modules 2>&1 | tee /tmp/build.log; then
             # Promote compiler diagnostics to annotations so a failure is
             # diagnosable from the checks API without opening the raw log.
-            grep -E 'error:|Error [0-9]+' /tmp/build.log | head -n 25 | while IFS= read -r line; do
-              echo "::error title=Build error::${line}"
-            done
+            grep -E 'error:|Error [0-9]+' /tmp/build.log | head -n 25 \
+              | sed 's|^|::error title=Build error::|'
             exit 1
           fi
 
       - name: Verify modules were produced
         run: |
-          FOUND=$(find driver/drivers/aic8800 -name '*.ko' -printf '%p\n' | sort)
+          FOUND=$(find driver/drivers/aic8800 -name '*.ko' | sort)
           if [ -z "$FOUND" ]; then
             echo "ERROR: build reported success but produced no .ko files"
             exit 1
@@ -188,6 +184,7 @@ jobs:
 
       - name: Check for unused-label warnings
         run: |
+          # Annotation rather than a build failure - see the build job for why.
           N=$(grep -c 'unused-label' /tmp/build.log || true)
           if [ "$N" -gt 0 ]; then
             echo "::warning title=Unused label::upstream ${{ matrix.tag }}: ${N} -Wunused-label warning(s)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,3 +88,65 @@ jobs:
           else
             echo "::warning title=Kernel coverage::${{ matrix.label }} = ${KVER}: below 7.2, so the >= 7.2 code path was NOT compiled by this job"
           fi
+
+  # Arch does not package kernel 7.2 yet, not even in the testing repositories,
+  # so the jobs above cannot compile the >= 7.2 code paths at all. Prepare an
+  # upstream tree instead - that is the only way to prove the 7.2 claim.
+  build-upstream:
+    name: Build against upstream ${{ matrix.tag }}
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:base-devel
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - v7.2
+    steps:
+      - name: Install toolchain
+        run: |
+          pacman -Syu --noconfirm --needed git bc cpio elfutils flex bison openssl perl python
+
+      - name: Checkout driver
+        uses: actions/checkout@v4
+        with:
+          path: driver
+
+      - name: Prepare upstream kernel ${{ matrix.tag }}
+        id: kernel
+        run: |
+          git clone --depth 1 --branch '${{ matrix.tag }}' \
+            https://github.com/torvalds/linux.git linux
+          cd linux
+          make -s -j"$(nproc)" defconfig
+          # modules_prepare only builds scripts and headers, so there is no
+          # Module.symvers; MODVERSIONS would then reject the out-of-tree build.
+          scripts/config --disable MODVERSIONS \
+                         --disable MODULE_SIG \
+                         --disable DEBUG_INFO_BTF \
+                         --enable MODULES \
+                         --module CFG80211 \
+                         --module MAC80211
+          make -s -j"$(nproc)" olddefconfig
+          make -s -j"$(nproc)" modules_prepare
+          KVER=$(make -s kernelrelease)
+          echo "kdir=${PWD}" >> "$GITHUB_OUTPUT"
+          echo "kver=${KVER}" >> "$GITHUB_OUTPUT"
+          echo "Prepared kernel ${KVER}"
+
+      - name: Build modules
+        run: |
+          make -C driver/drivers/aic8800 KDIR='${{ steps.kernel.outputs.kdir }}' modules
+
+      - name: Verify modules were produced
+        run: |
+          FOUND=$(find driver/drivers/aic8800 -name '*.ko' -printf '%p\n' | sort)
+          if [ -z "$FOUND" ]; then
+            echo "ERROR: build reported success but produced no .ko files"
+            exit 1
+          fi
+          echo "$FOUND"
+
+      - name: Report kernel coverage
+        run: |
+          echo "::notice title=Kernel coverage::upstream ${{ matrix.tag }} = ${{ steps.kernel.outputs.kver }}: exercises the >= 7.2 code path"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,3 +56,17 @@ jobs:
           fi
           echo "Built against kernel ${{ steps.kernel.outputs.kver }}:"
           echo "$FOUND"
+
+      - name: Report kernel coverage
+        run: |
+          # Surfaced as an annotation, not just log output, so which kernel was
+          # actually compiled against is visible without digging into the logs.
+          KVER='${{ steps.kernel.outputs.kver }}'
+          MAJ=${KVER%%.*}
+          REST=${KVER#*.}
+          MIN=${REST%%.*}
+          if [ "$MAJ" -gt 7 ] || { [ "$MAJ" -eq 7 ] && [ "$MIN" -ge 2 ]; }; then
+            echo "::notice title=Kernel coverage::${{ matrix.headers }} = ${KVER}: exercises the >= 7.2 code path"
+          else
+            echo "::warning title=Kernel coverage::${{ matrix.headers }} = ${KVER}: below 7.2, so the >= 7.2 code path was NOT compiled by this job"
+          fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,16 @@ jobs:
 
       - name: Build modules
         run: |
-          make -C driver/drivers/aic8800 KDIR='${{ steps.kernel.outputs.kdir }}' modules
+          set -o pipefail
+          if ! make -C driver/drivers/aic8800 \
+                 KDIR='${{ steps.kernel.outputs.kdir }}' modules 2>&1 | tee /tmp/build.log; then
+            # Promote compiler diagnostics to annotations so a failure is
+            # diagnosable from the checks API without opening the raw log.
+            grep -E 'error:|Error [0-9]+' /tmp/build.log | head -n 25 | while IFS= read -r line; do
+              echo "::error title=Build error::${line}"
+            done
+            exit 1
+          fi
 
       - name: Verify modules were produced
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,4 +5,4 @@ See `AGENTS.md` for code style and build conventions.
 ## Active constraints
 
 - 2026-08-27: Never perform rewording of comments for grammar purpose. Always emit ultra concise text, disregard grammatic correctness in favor of brevity
-- 2026-08-27: Do in-code comments unless they add real value for the reader and aren't just prose you celebrate yourself with
+- 2026-08-27: Don't add in-code comments unless they add real value for the reader; no self-congratulatory prose

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# CLAUDE.md
+
+See `AGENTS.md` for code style and build conventions.
+
+## Active constraints
+
+- 2026-08-27: Never perform rewording of comments for grammar purpose. Always emit ultra concise text, disregard grammatic correctness in favor of brevity
+- 2026-08-27: Do in-code comments unless they add real value for the reader and aren't just prose you celebrate yourself with

--- a/README.md
+++ b/README.md
@@ -4,8 +4,13 @@ AIC8800 WiFi driver for AIC8800D80/AIC8800DC/AIC8800DW chips, tested on CachyOS 
 
 ## Overview
 
-This driver provides fullmac WiFi support for AIC8800 series chips on Linux kernels 6.0+.
+This driver provides fullmac WiFi support for AIC8800 series chips on Linux kernels 6.0 through 7.2.
 Tested and verified on kernel 6.19.10 with LLVM/Clang compilation.
+
+Kernel 7.3 is **not** supported yet: upstream converted the cfg80211 `cookie`
+from an output to a pre-assigned input parameter, which changes the behaviour of
+`.remain_on_channel`, `.mgmt_tx` and `.probe_client` rather than just their
+signatures.
 
 ## Test Environment
 
@@ -14,6 +19,9 @@ Tested and verified on kernel 6.19.10 with LLVM/Clang compilation.
 - **Compiler**: LLVM/Clang 22.1.2
 - **Architecture**: x86_64
 - **USB Interface**: AIC8800D80 USB WiFi adapter
+
+Every pull request is additionally compiled in CI against the current Arch
+`linux-headers` and `linux-lts-headers` packages.
 
 ## Acknowledgments
 
@@ -24,6 +32,7 @@ This project references the following resources:
 
 ## Recent Updates
 
+- **2026.08.26**: Kernel 7.2 build support (`strncpy` removal, `.remain_on_channel` gained `rx_addr`), CI now compiles every PR
 - **2026.04.03**: Updated for kernel 6.19.10, verified LLVM compilation, added production configuration
 - **2025.11.11**: Linux Kernel 6.17.7-arch1-1 compilation verified
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ signatures.
 - **Architecture**: x86_64
 - **USB Interface**: AIC8800D80 USB WiFi adapter
 
-Every pull request is additionally compiled in CI against the current Arch
-`linux-headers` and `linux-lts-headers` packages.
+Every pull request is additionally compiled in CI against four kernels: the
+current Arch `linux-headers` and `linux-lts-headers`, the Arch testing headers,
+and an upstream v7.2 tree — the last of these is what actually exercises the
+7.2-specific code paths, since Arch does not package 7.2 yet.
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ implements all three.
 - **Architecture**: x86_64
 - **USB Interface**: AIC8800D80 USB WiFi adapter
 
-Every pull request is additionally compiled in CI against four kernels: the
-current Arch `linux-headers` and `linux-lts-headers`, the Arch testing headers,
-and an upstream v7.2 tree — the last of these is what actually exercises the
-7.2-specific code paths, since Arch does not package 7.2 yet.
+Every pull request is additionally compiled in CI against the current Arch
+`linux-headers` and `linux-lts-headers`, the Arch testing headers, and an
+upstream v7.2 tree built twice — once with gcc, once with clang. The upstream
+jobs are the ones that actually exercise the 7.2-specific code paths, since Arch
+does not package 7.2 yet, and they are also the only ones that compile the
+wireless-extensions path against 7.2.
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ AIC8800 WiFi driver for AIC8800D80/AIC8800DC/AIC8800DW chips, tested on CachyOS 
 This driver provides fullmac WiFi support for AIC8800 series chips on Linux kernels 6.0 through 7.2.
 Tested and verified on kernel 6.19.10 with LLVM/Clang compilation.
 
-Kernel 7.3 is **not** supported yet: upstream converted the cfg80211 `cookie`
+Kernel 7.3 is **not** supported yet. Upstream converted the cfg80211 `cookie`
 from an output to a pre-assigned input parameter, which changes the behaviour of
-`.remain_on_channel`, `.mgmt_tx` and `.probe_client` rather than just their
-signatures.
+`.remain_on_channel` and `.mgmt_tx` rather than just their signatures, and
+removed `.probe_client` from `struct cfg80211_ops` altogether. This driver
+implements all three.
 
 ## Test Environment
 

--- a/drivers/aic8800/aic8800_fdrv/aicwf_compat_8800d80.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_compat_8800d80.c
@@ -40,7 +40,13 @@ int	rwnx_plat_userconfig_load_8800d80(struct rwnx_hw *rwnx_hw){
     char *filename = FW_USERCONFIG_NAME_8800D80;
 
 #ifndef ANDROID_PLATFORM
-            sprintf(aic_fw_path, "%s/%s", aic_fw_path, "aic8800D80");
+    {
+        /* Passing aic_fw_path as both destination and source of sprintf() is
+         * undefined behaviour (-Wrestrict); append in place instead. */
+        size_t off = strlen(aic_fw_path);
+
+        snprintf(aic_fw_path + off, sizeof(aic_fw_path) - off, "/%s", "aic8800D80");
+    }
 #endif
 
     AICWFDBG(LOGINFO, "userconfig file path:%s \r\n", filename);

--- a/drivers/aic8800/aic8800_fdrv/aicwf_compat_8800d80.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_compat_8800d80.c
@@ -40,13 +40,7 @@ int	rwnx_plat_userconfig_load_8800d80(struct rwnx_hw *rwnx_hw){
     char *filename = FW_USERCONFIG_NAME_8800D80;
 
 #ifndef ANDROID_PLATFORM
-    {
-        /* Passing aic_fw_path as both destination and source of sprintf() is
-         * undefined behaviour (-Wrestrict); append in place instead. */
-        size_t off = strlen(aic_fw_path);
-
-        snprintf(aic_fw_path + off, sizeof(aic_fw_path) - off, "/%s", "aic8800D80");
-    }
+    aic_fw_path_append("aic8800D80");
 #endif
 
     AICWFDBG(LOGINFO, "userconfig file path:%s \r\n", filename);

--- a/drivers/aic8800/aic8800_fdrv/aicwf_compat_8800d80x2.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_compat_8800d80x2.c
@@ -41,7 +41,13 @@ int	rwnx_plat_userconfig_load_8800d80x2(struct rwnx_hw *rwnx_hw){
     char *filename = FW_USERCONFIG_NAME_8800D80X2;
 
 #ifndef ANDROID_PLATFORM
-    sprintf(aic_fw_path, "%s/%s", aic_fw_path, "aic8800D80X2");
+    {
+        /* Passing aic_fw_path as both destination and source of sprintf() is
+         * undefined behaviour (-Wrestrict); append in place instead. */
+        size_t off = strlen(aic_fw_path);
+
+        snprintf(aic_fw_path + off, sizeof(aic_fw_path) - off, "/%s", "aic8800D80X2");
+    }
 #endif
 
     AICWFDBG(LOGINFO, "userconfig file path:%s \r\n", filename);

--- a/drivers/aic8800/aic8800_fdrv/aicwf_compat_8800d80x2.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_compat_8800d80x2.c
@@ -41,13 +41,7 @@ int	rwnx_plat_userconfig_load_8800d80x2(struct rwnx_hw *rwnx_hw){
     char *filename = FW_USERCONFIG_NAME_8800D80X2;
 
 #ifndef ANDROID_PLATFORM
-    {
-        /* Passing aic_fw_path as both destination and source of sprintf() is
-         * undefined behaviour (-Wrestrict); append in place instead. */
-        size_t off = strlen(aic_fw_path);
-
-        snprintf(aic_fw_path + off, sizeof(aic_fw_path) - off, "/%s", "aic8800D80X2");
-    }
+    aic_fw_path_append("aic8800D80X2");
 #endif
 
     AICWFDBG(LOGINFO, "userconfig file path:%s \r\n", filename);

--- a/drivers/aic8800/aic8800_fdrv/aicwf_wext_linux.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_wext_linux.c
@@ -400,8 +400,8 @@ static char *aicwf_get_iwe_stream_mac_addr(struct rwnx_hw* rwnx_hw,
 	iwe->cmd = SIOCGIWAP;
 	iwe->u.ap_addr.sa_family = ARPHRD_ETHER;
 
-	if(scan_re->bss && &scan_re->bss->bssid[0]){
-	memcpy(iwe->u.ap_addr.sa_data, scan_re->bss->bssid, ETH_ALEN);
+	if (scan_re->bss) {
+		memcpy(iwe->u.ap_addr.sa_data, scan_re->bss->bssid, ETH_ALEN);
 	}
 
 	start = iwe_stream_add_event(info, start, stop, iwe, IW_EV_ADDR_LEN);

--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -4343,31 +4343,22 @@ static int rwnx_cfg80211_set_txq_params(struct wiphy *wiphy, struct net_device *
  */
 
 static int
-rwnx_cfg80211_remain_on_channel_(struct wiphy *wiphy,
-                            #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 6, 0)
-                                struct wireless_dev *wdev,
-                            #else
-                                struct net_device *dev,
-                            #endif
+rwnx_cfg80211_remain_on_channel_(struct wiphy *wiphy, struct wireless_dev *wdev,
                                 struct ieee80211_channel *chan,
-                            #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 8, 0)
-                                enum nl80211_channel_type channel_type,
-                            #endif
                                 unsigned int duration, u64 *cookie, bool mgmt_roc_flag)
 {
     struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 6, 0)
     struct rwnx_vif *rwnx_vif = container_of(wdev, struct rwnx_vif, wdev);
-#else
-    struct rwnx_vif *rwnx_vif = netdev_priv(dev);
-    struct wireless_dev *wdev = &rwnx_vif->wdev;
-#endif
     struct rwnx_roc_elem *roc_elem;
     struct mm_add_if_cfm add_if_cfm;
     struct mm_remain_on_channel_cfm roc_cfm;
     int error;
 
     RWNX_DBG(RWNX_FN_ENTRY_STR);
+
+    /* cfg80211 dereferences *cookie for its return tracepoint without checking
+     * our return value, so it must never be left holding uninitialised stack */
+    *cookie = 0;
 
     /* For debug purpose (use ftrace kernel option) */
 #ifdef CREATE_TRACE_POINTS
@@ -4481,34 +4472,29 @@ rwnx_cfg80211_remain_on_channel_(struct wiphy *wiphy,
 }
 
 
+/*
+ * Kernel 7.2 added the @rx_addr MAC-address filter to .remain_on_channel.
+ * Ignoring it is safe here: cfg80211 rejects a non-NULL rx_addr with -EOPNOTSUPP
+ * unless the driver advertises NL80211_EXT_FEATURE_ROC_ADDR_FILTER, and this
+ * driver advertises no ext features at all, so rx_addr is always NULL. If that
+ * ever changes, RoC address filtering must be implemented here or it becomes a
+ * silent no-op.
+ *
+ * The guard is deliberately bounded at 7.3: upstream has since converted the
+ * cookie from an output to a pre-assigned input parameter (u64 cookie), which
+ * is a behaviour change, not just a signature change, and affects .mgmt_tx and
+ * .probe_client as well.
+ */
 static int
-rwnx_cfg80211_remain_on_channel(struct wiphy *wiphy,
-                            #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 6, 0)
-                                struct wireless_dev *wdev,
-                            #else
-                                struct net_device *dev,
-                            #endif
+rwnx_cfg80211_remain_on_channel(struct wiphy *wiphy, struct wireless_dev *wdev,
                                 struct ieee80211_channel *chan,
-                            #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 8, 0)
-                                enum nl80211_channel_type channel_type,
-                            #endif
                                 unsigned int duration, u64 *cookie
                             #if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0)
-                                , const u8 *rx_addr
+                                , const u8 *rx_addr __always_unused
                             #endif
-                            )
+                                )
 {
-	return rwnx_cfg80211_remain_on_channel_(wiphy,
-                            #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 6, 0)
-                                wdev,
-                            #else
-                                dev,
-                            #endif
-                                chan,
-                            #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 8, 0)
-                                channel_type,
-                            #endif
-                                duration, cookie, false);
+	return rwnx_cfg80211_remain_on_channel_(wiphy, wdev, chan, duration, cookie, false);
 }
 
 /**
@@ -4795,16 +4781,8 @@ static int rwnx_cfg80211_mgmt_tx(struct wiphy *wiphy, struct wireless_dev *wdev,
 		AICWFDBG(LOGINFO, "mgmt rx remain on chan\n");
 
         /* Start a ROC procedure for 30ms */
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
         error = rwnx_cfg80211_remain_on_channel_(wiphy, wdev, channel,
                                                 30, &cookie, true);
-#elif (LINUX_VERSION_CODE < KERNEL_VERSION(3, 8, 0)) && (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 6, 0))
-        error = rwnx_cfg80211_remain_on_channel_(wiphy, wdev, channel, NL80211_CHAN_NO_HT,
-                                                30, &cookie, true);
-#else
-        error = rwnx_cfg80211_remain_on_channel_(wiphy, dev, channel, NL80211_CHAN_NO_HT,
-                                                30, &cookie, true);
-#endif
 
         if (error) {
 			AICWFDBG(LOGERROR, "mgmt rx chan err\n");

--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -4492,7 +4492,11 @@ rwnx_cfg80211_remain_on_channel(struct wiphy *wiphy,
                             #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 8, 0)
                                 enum nl80211_channel_type channel_type,
                             #endif
-                                unsigned int duration, u64 *cookie)
+                                unsigned int duration, u64 *cookie
+                            #if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0)
+                                , const u8 *rx_addr
+                            #endif
+                            )
 {
 	return rwnx_cfg80211_remain_on_channel_(wiphy,
                             #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 6, 0)

--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -4480,10 +4480,7 @@ rwnx_cfg80211_remain_on_channel_(struct wiphy *wiphy, struct wireless_dev *wdev,
  * ever changes, RoC address filtering must be implemented here or it becomes a
  * silent no-op.
  *
- * The guard is deliberately bounded at 7.3: upstream has since converted the
- * cookie from an output to a pre-assigned input parameter (u64 cookie), which
- * is a behaviour change, not just a signature change, and affects .mgmt_tx and
- * .probe_client as well.
+ * 7.3 needs more than another parameter here - see README.
  */
 static int
 rwnx_cfg80211_remain_on_channel(struct wiphy *wiphy, struct wireless_dev *wdev,

--- a/drivers/aic8800/aic8800_fdrv/rwnx_msg_rx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_msg_rx.c
@@ -822,9 +822,7 @@ static inline int rwnx_rx_scanu_result_ind(struct rwnx_hw *rwnx_hw,
 #endif
 
     }
-/* Both "goto putbss" statements live inside CONFIG_USE_WIRELESS_EXT above, so
- * the label is unreferenced without it (-Wunused-label). The cleanup below is
- * still the normal fall-through path in either configuration. */
+    /* only referenced from the CONFIG_USE_WIRELESS_EXT block above */
 #ifdef CONFIG_USE_WIRELESS_EXT
 putbss:
 #endif

--- a/drivers/aic8800/aic8800_fdrv/rwnx_msg_rx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_msg_rx.c
@@ -822,7 +822,12 @@ static inline int rwnx_rx_scanu_result_ind(struct rwnx_hw *rwnx_hw,
 #endif
 
     }
+/* Both "goto putbss" statements live inside CONFIG_USE_WIRELESS_EXT above, so
+ * the label is unreferenced without it (-Wunused-label). The cleanup below is
+ * still the normal fall-through path in either configuration. */
+#ifdef CONFIG_USE_WIRELESS_EXT
 putbss:
+#endif
     if (bss != NULL)
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 9, 0)
 	cfg80211_put_bss(bss);

--- a/drivers/aic8800/aic8800_fdrv/rwnx_msg_tx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_msg_tx.c
@@ -16,6 +16,7 @@
 #ifdef CONFIG_RWNX_BFMER
 #include "rwnx_bfmer.h"
 #endif //(CONFIG_RWNX_BFMER)
+#include <linux/string.h>
 #include "rwnx_compat.h"
 #include "rwnx_cmds.h"
 

--- a/drivers/aic8800/aic8800_fdrv/rwnx_msg_tx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_msg_tx.c
@@ -4707,8 +4707,7 @@ int rwnx_send_dbg_trigger_req(struct rwnx_hw *rwnx_hw, char *msg)
         return -ENOMEM;
 
     /* Set parameters for the MM_DBG_TRIGGER_REQ message */
-    /* strscpy() always NUL-terminates; strncpy() did not, and was removed from
-     * the kernel in 7.2.0 (last declared in 7.1 include/linux/string.h) */
+    /* strscpy() NUL-terminates; strncpy() did not, and was removed in 7.2 */
     strscpy(req->error, msg, sizeof(req->error));
 
     /* Send the MM_DBG_TRIGGER_REQ message to LMAC FW */

--- a/drivers/aic8800/aic8800_fdrv/rwnx_msg_tx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_msg_tx.c
@@ -10,13 +10,13 @@
  ******************************************************************************
  */
 
+#include <linux/string.h>
 #include "rwnx_msg_tx.h"
 #include "rwnx_mod_params.h"
 #include "reg_access.h"
 #ifdef CONFIG_RWNX_BFMER
 #include "rwnx_bfmer.h"
 #endif //(CONFIG_RWNX_BFMER)
-#include <linux/string.h>
 #include "rwnx_compat.h"
 #include "rwnx_cmds.h"
 
@@ -4707,7 +4707,9 @@ int rwnx_send_dbg_trigger_req(struct rwnx_hw *rwnx_hw, char *msg)
         return -ENOMEM;
 
     /* Set parameters for the MM_DBG_TRIGGER_REQ message */
-    strncpy(req->error, msg, sizeof(req->error));
+    /* strscpy() always NUL-terminates; strncpy() did not, and was removed from
+     * the kernel in 7.2.0 (last declared in 7.1 include/linux/string.h) */
+    strscpy(req->error, msg, sizeof(req->error));
 
     /* Send the MM_DBG_TRIGGER_REQ message to LMAC FW */
     return rwnx_send_msg(rwnx_hw, req, 0, -1, NULL);

--- a/drivers/aic8800/aic8800_fdrv/rwnx_platform.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_platform.c
@@ -3034,7 +3034,10 @@ int ParseQualifiedString(char *In, u32 *Start, char *Out, char LeftQualifier, ch
     if (c == '\0')
         return 0;
     j = (*Start) - 2;
-    strncpy((char *)Out, (const char *)(In + i), j - i + 1);
+    /* memcpy(), not strscpy(): the source is a longer line and the caller
+     * pre-zeroes Out, so this is byte-identical to the strncpy() it replaces
+     * (strncpy() was removed from the kernel in 7.2.0) */
+    memcpy((char *)Out, (const char *)(In + i), j - i + 1);
     return 1;
 }
 
@@ -3247,7 +3250,7 @@ void rwnx_plat_powerlimit_parsing(char *buffer, int size, char *cc)
 					goto exit;
 				}
 
-				strncpy(reg_name[forCnt], szLine + i_cc, i - i_cc);
+				memcpy(reg_name[forCnt], szLine + i_cc, i - i_cc);
 				reg_name[forCnt][i - i_cc] = '\0';
 				AICWFDBG(LOGINFO, "reg_name: %s\n", reg_name[forCnt]);
 

--- a/drivers/aic8800/aic8800_fdrv/rwnx_platform.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_platform.c
@@ -1586,13 +1586,7 @@ static int rwnx_plat_patch_load(struct rwnx_hw *rwnx_hw)
     if(rwnx_hw->usbdev->chipid == PRODUCT_ID_AIC8800DC ||
         rwnx_hw->usbdev->chipid == PRODUCT_ID_AIC8800DW){
 #ifndef ANDROID_PLATFORM
-        {
-            /* Passing aic_fw_path as both destination and source of sprintf()
-             * is undefined behaviour (-Wrestrict); append in place instead. */
-            size_t off = strlen(aic_fw_path);
-
-            snprintf(aic_fw_path + off, sizeof(aic_fw_path) - off, "/%s", "aic8800DC");
-        }
+        aic_fw_path_append("aic8800DC");
 #endif
         AICWFDBG(LOGINFO, "testmode=%d\n", testmode);
         if (chip_sub_id == 0) {
@@ -3043,7 +3037,7 @@ int ParseQualifiedString(char *In, u32 *Start, char *Out, char LeftQualifier, ch
     /* memcpy(), not strscpy(): the source is a longer line and the caller
      * pre-zeroes Out, so this is byte-identical to the strncpy() it replaces
      * (strncpy() was removed from the kernel in 7.2.0) */
-    memcpy((char *)Out, (const char *)(In + i), j - i + 1);
+    memcpy(Out, In + i, j - i + 1);
     return 1;
 }
 

--- a/drivers/aic8800/aic8800_fdrv/rwnx_platform.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_platform.c
@@ -1586,7 +1586,13 @@ static int rwnx_plat_patch_load(struct rwnx_hw *rwnx_hw)
     if(rwnx_hw->usbdev->chipid == PRODUCT_ID_AIC8800DC ||
         rwnx_hw->usbdev->chipid == PRODUCT_ID_AIC8800DW){
 #ifndef ANDROID_PLATFORM
-        sprintf(aic_fw_path, "%s/%s", aic_fw_path, "aic8800DC");
+        {
+            /* Passing aic_fw_path as both destination and source of sprintf()
+             * is undefined behaviour (-Wrestrict); append in place instead. */
+            size_t off = strlen(aic_fw_path);
+
+            snprintf(aic_fw_path + off, sizeof(aic_fw_path) - off, "/%s", "aic8800DC");
+        }
 #endif
         AICWFDBG(LOGINFO, "testmode=%d\n", testmode);
         if (chip_sub_id == 0) {

--- a/drivers/aic8800/aic8800_fdrv/rwnx_platform.h
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_platform.h
@@ -186,6 +186,25 @@ void get_userconfig_xtal_cap(xtal_cap_conf_t *xtal_cap);
 int rwnx_request_firmware_common(struct rwnx_hw *rwnx_hw, u32** buffer, const char *filename);
 void rwnx_release_firmware_common(u32** buffer);
 void rwnx_plat_userconfig_parsing_8800d80x2(char *buffer, int size);
+
+#define AIC_FW_PATH_MAX 200
+extern char aic_fw_path[AIC_FW_PATH_MAX];
+
+/**
+ * aic_fw_path_append() - append a chip sub-directory to the firmware path
+ *
+ * The firmware lookups all read aic_fw_path as their base directory, so the
+ * chip sub-directory is appended in place. Deliberately not
+ * sprintf(aic_fw_path, "%s/%s", aic_fw_path, subdir): overlapping source and
+ * destination is undefined behaviour (-Wrestrict).
+ */
+static inline void aic_fw_path_append(const char *subdir)
+{
+    size_t off = strlen(aic_fw_path);
+
+    scnprintf(aic_fw_path + off, sizeof(aic_fw_path) - off, "/%s", subdir);
+}
+
 static inline unsigned int rwnx_platform_get_irq(struct rwnx_plat *rwnx_plat)
 {
     return rwnx_plat->pci_dev->irq;

--- a/drivers/aic8800/aic8800_fdrv/rwnx_platform.h
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_platform.h
@@ -11,7 +11,10 @@
 #ifndef _RWNX_PLATFORM_H_
 #define _RWNX_PLATFORM_H_
 
+/* kernel.h not sprintf.h: sprintf.h absent on 6.0, kernel.h declares scnprintf there */
+#include <linux/kernel.h>
 #include <linux/pci.h>
+#include <linux/string.h>
 #include "lmac_msg.h"
 
 


### PR DESCRIPTION
## Problem

DKMS module fails to build on kernel 7.2 (e.g. CachyOS 7.2.0-1-cachyos) with clang:

```
aic8800_fdrv/rwnx_msg_tx.c:4709:5: error: call to undeclared library function 'strncpy' with type 'char *(char *, const char *, __size_t)' (aka 'char *(char *, const char *, unsigned long)'); ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]

aic8800_fdrv/rwnx_main.c:6191:26: error: incompatible function pointer types initializing 'int (*)(struct wiphy *, struct wireless_dev *, struct ieee80211_channel *, unsigned int, u64 *, const u8 *)' with an expression of type 'int (struct wiphy *, struct wireless_dev *, struct ieee80211_channel *, unsigned int, u64 *)' [-Wincompatible-function-pointer-types]
```

## Changes

1. **rwnx_msg_tx.c** — Add `#include <linux/string.h>` for `strncpy` (clang 17+ rejects implicit function declarations)

2. **rwnx_main.c** — Add `const u8 *rx_addr` parameter to `rwnx_cfg80211_remain_on_channel` for kernel 7.2+, matching the new `cfg80211_ops.remain_on_channel` signature in upstream Linux

Both changes are guarded by `#if LINUX_VERSION_CODE` checks for backward compatibility with older kernels.

## Build Verification

Tested building against kernel 6.18.42-1-cachyos-lts (clang) — 0 warnings, 0 errors.