### PR TITLE
ci: distribute the driver as a pacman repository on GitHub Pages

### DIFF
--- a/.github/workflows/pacman-repo.yml
+++ b/.github/workflows/pacman-repo.yml
@@ -174,14 +174,21 @@ jobs:
           # Resolve and download through the real URL, not a local path: this is
           # what catches anything Pages serves differently from the filesystem,
           # such as the symlinks repo-add creates.
-          docker run --rm archlinux:base bash -euo pipefail -c '
+          set -o pipefail
+          if ! docker run --rm archlinux:base bash -euo pipefail -c '
             printf "[%s]\nSigLevel = Optional TrustAll\nServer = %s\n" \
               "'"${REPO_NAME}"'" "'"${BASE}"'x86_64" >> /etc/pacman.conf
-            pacman -Sy --noconfirm >/dev/null
+            pacman -Sy --noconfirm
             pacman -Si "'"${REPO_NAME}"'/aic8800-fdrv-dkms" | head -n 8
+            mkdir -p /tmp/cache
             pacman -Sw --noconfirm --cachedir /tmp/cache "'"${REPO_NAME}"'/aic8800-fdrv-dkms"
             ls -l /tmp/cache/*.pkg.tar.zst
-          '
+          ' 2>&1 | tee /tmp/smoke.log; then
+            tail -n 15 /tmp/smoke.log | while IFS= read -r line; do
+              echo "::error title=Smoke test::${line}"
+            done
+            exit 1
+          fi
           echo "::notice title=Smoke test::pacman resolved and downloaded the package from ${BASE}x86_64"
 
       - name: Report published repository

--- a/.github/workflows/pacman-repo.yml
+++ b/.github/workflows/pacman-repo.yml
@@ -6,12 +6,6 @@ on:
   # Manual re-publish, e.g. after deleting a release or changing the layout.
   # Rebuilds from whatever releases currently exist, so it is always safe to run.
   workflow_dispatch:
-  # TEMPORARY: lets this be validated before it reaches the default branch.
-  # Removed before merge - workflow_dispatch is not selectable until the file
-  # exists on the default branch.
-  push:
-    branches:
-      - feat/pacman-repo-pages
 
 permissions:
   contents: read

--- a/.github/workflows/pacman-repo.yml
+++ b/.github/workflows/pacman-repo.yml
@@ -156,6 +156,34 @@ jobs:
         id: deploy
         uses: actions/deploy-pages@v4
 
+      - name: Smoke-test the published repository over HTTPS
+        run: |
+          BASE='${{ steps.deploy.outputs.page_url }}'
+          DB="${BASE}x86_64/${REPO_NAME}.db"
+          # A fresh deployment can take a moment to be served.
+          for i in $(seq 1 20); do
+            CODE=$(curl -sS -o /dev/null -w '%{http_code}' "$DB" || true)
+            [ "$CODE" = "200" ] && break
+            echo "attempt ${i}: ${DB} -> ${CODE}, retrying"
+            sleep 15
+          done
+          if [ "$CODE" != "200" ]; then
+            echo "::error title=Repo unreachable::${DB} returned ${CODE}"
+            exit 1
+          fi
+          # Resolve and download through the real URL, not a local path: this is
+          # what catches anything Pages serves differently from the filesystem,
+          # such as the symlinks repo-add creates.
+          docker run --rm archlinux:base bash -euo pipefail -c '
+            printf "[%s]\nSigLevel = Optional TrustAll\nServer = %s\n" \
+              "'"${REPO_NAME}"'" "'"${BASE}"'x86_64" >> /etc/pacman.conf
+            pacman -Sy --noconfirm >/dev/null
+            pacman -Si "'"${REPO_NAME}"'/aic8800-fdrv-dkms" | head -n 8
+            pacman -Sw --noconfirm --cachedir /tmp/cache "'"${REPO_NAME}"'/aic8800-fdrv-dkms"
+            ls -l /tmp/cache/*.pkg.tar.zst
+          '
+          echo "::notice title=Smoke test::pacman resolved and downloaded the package from ${BASE}x86_64"
+
       - name: Report published repository
         run: |
           echo "::notice title=Pacman repo::published at ${{ steps.deploy.outputs.page_url }}x86_64"

--- a/.github/workflows/pacman-repo.yml
+++ b/.github/workflows/pacman-repo.yml
@@ -1,0 +1,161 @@
+name: Pacman repository
+
+on:
+  # Called by release.yml once a release exists.
+  workflow_call:
+  # Manual re-publish, e.g. after deleting a release or changing the layout.
+  # Rebuilds from whatever releases currently exist, so it is always safe to run.
+  workflow_dispatch:
+  # TEMPORARY: lets this be validated before it reaches the default branch.
+  # Removed before merge - workflow_dispatch is not selectable until the file
+  # exists on the default branch.
+  push:
+    branches:
+      - feat/pacman-repo-pages
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never let two Pages deployments race; queue instead of cancelling, so a
+# release publish is not dropped by a manual re-run.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  REPO_NAME: aic8800
+
+jobs:
+  publish:
+    name: Publish pacman repository to Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Collect packages from releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p repo/x86_64
+          # Rebuild from the releases rather than from a single build, so the
+          # repository is reproducible and older versions stay installable.
+          mapfile -t TAGS < <(gh release list --repo "$GITHUB_REPOSITORY" \
+            --limit 10 --json tagName --jq '.[].tagName')
+          if [ "${#TAGS[@]}" -eq 0 ]; then
+            echo "ERROR: no releases found, nothing to publish"
+            exit 1
+          fi
+          echo "Considering ${#TAGS[@]} release(s): ${TAGS[*]}"
+          for t in "${TAGS[@]}"; do
+            gh release download "$t" --repo "$GITHUB_REPOSITORY" \
+              --pattern '*.pkg.tar.zst' --dir repo/x86_64 --clobber \
+              || echo "note: ${t} has no pacman package asset, skipping"
+          done
+          COUNT=$(find repo/x86_64 -name '*.pkg.tar.zst' | wc -l)
+          if [ "$COUNT" -eq 0 ]; then
+            echo "ERROR: none of the ${#TAGS[@]} release(s) carry a .pkg.tar.zst asset"
+            exit 1
+          fi
+          echo "::notice title=Packages::collected ${COUNT} package(s) from ${#TAGS[@]} release(s)"
+          ls -1 repo/x86_64
+
+      - name: Build repository database
+        run: |
+          docker run --rm -v "${PWD}/repo/x86_64:/repo" -w /repo archlinux:base \
+            bash -euo pipefail -c '
+              # Version-sort so the newest package is added last: a pacman db
+              # holds one entry per pkgname, and the last one added wins.
+              mapfile -t PKGS < <(ls -1 *.pkg.tar.zst | sort -V)
+              printf "adding: %s\n" "${PKGS[@]}"
+              repo-add "'"${REPO_NAME}"'.db.tar.zst" "${PKGS[@]}"
+              # Pages does not serve symlinks, and pacman fetches the bare
+              # .db/.files names, so replace repo-adds symlinks with real files.
+              for l in "'"${REPO_NAME}"'.db" "'"${REPO_NAME}"'.files"; do
+                if [ -L "$l" ]; then t=$(readlink "$l"); rm "$l"; cp "$t" "$l"; fi
+              done
+            '
+          echo "--- repository contents ---"
+          ls -l repo/x86_64
+
+      - name: Verify the database is readable by pacman
+        run: |
+          # A served db that pacman cannot parse would fail silently on users'
+          # machines, so assert the package is actually resolvable from it.
+          docker run --rm -v "${PWD}/repo/x86_64:/repo:ro" archlinux:base \
+            bash -euo pipefail -c '
+              printf "[%s]\nSigLevel = Optional TrustAll\nServer = file:///repo\n" "'"${REPO_NAME}"'" \
+                >> /etc/pacman.conf
+              pacman -Sy --noconfirm >/dev/null
+              pacman -Si "'"${REPO_NAME}"'/aic8800-fdrv-dkms" | head -n 12
+            '
+
+      - name: Configure Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Write landing page
+        run: |
+          BASE='${{ steps.pages.outputs.base_url }}'
+          cat > repo/index.html <<HTML
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <title>AIC8800 pacman repository</title>
+            <style>
+              body { font-family: system-ui, sans-serif; max-width: 46rem;
+                     margin: 3rem auto; padding: 0 1rem; line-height: 1.6; }
+              pre { background: #f4f4f5; padding: 1rem; border-radius: 6px;
+                    overflow-x: auto; }
+              code { font-family: ui-monospace, monospace; }
+            </style>
+          </head>
+          <body>
+            <h1>AIC8800 pacman repository</h1>
+            <p>DKMS packages of the
+              <a href="https://github.com/${GITHUB_REPOSITORY}">AIC8800 Linux driver</a>
+              for Arch Linux and CachyOS.</p>
+
+            <h2>Add the repository</h2>
+            <p>Append to <code>/etc/pacman.conf</code>:</p>
+          <pre>[${REPO_NAME}]
+          SigLevel = Optional TrustAll
+          Server = ${BASE}/x86_64</pre>
+
+            <h2>Install</h2>
+          <pre>sudo pacman -Sy ${REPO_NAME}/aic8800-fdrv-dkms</pre>
+            <p>Install the headers matching your kernel as well, e.g.
+              <code>linux-headers</code>, <code>linux-cachyos-headers</code>,
+              <code>linux-lts-headers</code> or <code>linux-zen-headers</code>.
+              DKMS then rebuilds the modules on every kernel update.</p>
+
+            <h2>A note on signing</h2>
+            <p>These packages are <strong>not</strong> PGP signed, which is why
+              <code>SigLevel = Optional TrustAll</code> is required. You are
+              trusting GitHub Pages and this repository's release pipeline. If
+              that is not acceptable, build from the
+              <a href="https://github.com/${GITHUB_REPOSITORY}/releases">PKGBUILD</a>
+              instead.</p>
+          </body>
+          </html>
+          HTML
+          # Keep Jekyll from reinterpreting the repository files.
+          touch repo/.nojekyll
+          echo "landing page written for base_url=${BASE}"
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: repo
+
+      - name: Deploy to Pages
+        id: deploy
+        uses: actions/deploy-pages@v4
+
+      - name: Report published repository
+        run: |
+          echo "::notice title=Pacman repo::published at ${{ steps.deploy.outputs.page_url }}x86_64"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,3 +128,15 @@ jobs:
             PKGBUILD
             .SRCINFO
             aic8800-fdrv-dkms.install
+
+  # Runs only after the release exists, since the repository is built from
+  # release assets. Using needs: rather than a workflow_run trigger keeps the
+  # ordering explicit instead of racing release creation.
+  publish-repo:
+    name: Publish pacman repository
+    needs: release
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/pacman-repo.yml

--- a/README.md
+++ b/README.md
@@ -27,6 +27,31 @@ This project references the following resources:
 - **2026.04.03**: Updated for kernel 6.19.10, verified LLVM compilation, added production configuration
 - **2025.11.11**: Linux Kernel 6.17.7-arch1-1 compilation verified
 
+## Installation on Arch Linux / CachyOS (pacman repository)
+
+The recommended route. Add the repository once and updates arrive with a normal
+`pacman -Syu`. Append to `/etc/pacman.conf`:
+
+```ini
+[aic8800]
+SigLevel = Optional TrustAll
+Server = https://ronnyf.github.io/AIC8800-Linux-Driver/x86_64
+```
+
+Then install, along with the headers matching your kernel:
+
+```bash
+sudo pacman -Sy aic8800/aic8800-fdrv-dkms
+sudo pacman -S linux-headers          # or linux-cachyos-headers, linux-lts-headers, linux-zen-headers
+```
+
+DKMS rebuilds the modules automatically on each kernel update.
+
+> The packages are **not** PGP signed, which is why `SigLevel = Optional TrustAll`
+> is required — you are trusting GitHub Pages and this repository's release
+> pipeline. If that is not acceptable, build from the `PKGBUILD` attached to a
+> [release](https://github.com/ronnyf/AIC8800-Linux-Driver/releases) instead.
+
 ## Compilation and Installation
 
 ```bash


### PR DESCRIPTION
## Problem

Releases already attach a `.pkg.tar.zst`, but installing it meant a manual `curl` + `pacman -U` on every update. There was no *distribution* mechanism — nothing that lets `pacman -Syu` see a new version.

## Change

Publishes a real pacman repository to GitHub Pages. Arch/CachyOS users add it to `/etc/pacman.conf` once:

```ini
[aic8800]
SigLevel = Optional TrustAll
Server = https://ronnyf.github.io/AIC8800-Linux-Driver/x86_64
```

…then `sudo pacman -Sy aic8800/aic8800-fdrv-dkms`, and later versions arrive with a normal system upgrade.

`pacman-repo.yml` is a reusable workflow. `release.yml` calls it with `needs: release`, so it runs only once the release exists — deliberately `needs:` rather than a `workflow_run` trigger, because the repository is built *from* release assets and must not race release creation. It also exposes `workflow_dispatch`, so the repository can be rebuilt at any time without cutting a tag.

## Design notes

- **Rebuilt from releases, not from a single build.** Up to the last 10 releases are collected, so the repository is reproducible from scratch and older versions stay installable.
- **Packages added version-sorted.** A pacman db holds one entry per `pkgname` and the last one added wins, so `sort -V` guarantees users get the newest rather than whatever order the shell glob produced.
- **`repo-add`'s symlinks are replaced with real files.** Pages does not serve symlinks and pacman requests the bare `.db`/`.files` names.
- **Two verification layers.** One loads the finished db in a container over `file://` to prove it parses; the other runs *after* deployment and has pacman resolve **and download** the package through the live HTTPS URL. The second exists because the first cannot catch anything Pages serves differently from the filesystem — which is exactly the symlink problem above.

## Verification

Ran end to end from this branch before the temporary test trigger was removed:

```
Packages:   collected 3 package(s) from 4 release(s)
Smoke test: pacman resolved and downloaded the package from
            https://ronnyf.github.io/AIC8800-Linux-Driver/x86_64
```

Every step green, including both verification layers. Two things had to be enabled to get there, both now in their final state: GitHub Pages is set to build from Actions, and the temporary `github-pages` deployment-branch exception for this branch has been deleted (only `main` is allowed again).

## Caveats

- **Packages are unsigned**, hence `SigLevel = Optional TrustAll`. Users are trusting GitHub Pages and this pipeline. Signing with a repo-held GPG key is the obvious follow-up if that trust boundary matters; it needs a private key secret, so it is deliberately not bundled in here.
- The repository is `x86_64` only, matching the release assets. The package itself is `arch=('any')`.
- The first `pacman -Syu` after merge will only see versions from existing releases; nothing republishes automatically until the next tag or a manual dispatch.
