### PR TITLE
fix: bound the vendor logger ring-name copy (stack buffer overflow)

### DIFF
--- a/drivers/aic8800/aic8800_fdrv/aic_vendor.c
+++ b/drivers/aic8800/aic8800_fdrv/aic_vendor.c
@@ -511,7 +511,9 @@ static int aicwf_vendor_logger_start_logging(struct wiphy *wiphy, struct wireles
 			size = nla_get_u32(iter);
 			break;
 		case LOGGER_ATTRIBUTE_RING_NAME:
-			strcpy(rb.name, nla_data(iter));
+			/* Bounded and NUL-terminating: nla_data() is neither length-checked
+			 * nor guaranteed NUL-terminated, so strcpy() overran rb.name. */
+			nla_strscpy((char *)rb.name, iter, sizeof(rb.name));
 			break;
 		default:
 			AICWFDBG(LOGERROR, "%s(%d), Unknown type: %d\n", __func__, __LINE__, type);
@@ -545,7 +547,9 @@ static int aicwf_vendor_logger_get_ring_data(struct wiphy *wiphy, struct wireles
 		type = nla_type(iter);
 		switch (type) {
 		case LOGGER_ATTRIBUTE_RING_NAME:
-			strcpy(rb.name, nla_data(iter));
+			/* Bounded and NUL-terminating: nla_data() is neither length-checked
+			 * nor guaranteed NUL-terminated, so strcpy() overran rb.name. */
+			nla_strscpy((char *)rb.name, iter, sizeof(rb.name));
 			break;
 		default:
 			pr_err("%s(%d), Unknown type: %d\n", __func__, __LINE__, type);


### PR DESCRIPTION
## Problem

Both vendor logger handlers copy a netlink attribute into a fixed stack buffer with no bound:

```c
case LOGGER_ATTRIBUTE_RING_NAME:
        strcpy(rb.name, nla_data(iter));
```

- `aic_vendor.c:514` — `aicwf_vendor_logger_start_logging()`
- `aic_vendor.c:548` — `aicwf_vendor_logger_get_ring_data()`

`rb` is an uninitialised on-stack `struct wifi_ring_buffer_status`, whose `name` field is `u8 name[32]` (`aic_vendor.h:288`). `nla_data()` returns a pointer into the netlink message — the length is **not** checked and the payload is **not** guaranteed NUL-terminated. A `LOGGER_ATTRIBUTE_RING_NAME` attribute longer than 31 bytes therefore writes past `rb.name` and corrupts the stack frame.

Reachable by any process with `CAP_NET_ADMIN`, and `aic_vendor.o` is compiled unconditionally (`aic8800_fdrv/Makefile:190`).

## Fix

`nla_strscpy()`, which bounds the copy by the destination size and always NUL-terminates.

No version guard needed — verified identical in signature across the full supported range: `include/net/netlink.h:509` on `v6.0` and `:549` on `v7.2`. Truncation degrades safely: a clipped name matches no ring, and the existing lookup already returns `-EINVAL`.

## Verification

Honest limitation: **not compile-verified.** The build workflow lives on the `fix/kernel-7.2-build` branch (#15) and does not exist on `main` yet, so no CI job runs against this branch. What I did verify:

- both call sites and the 32-byte destination, read directly;
- `aic_vendor.o` is unconditionally in the object list;
- `nla_strscpy`'s presence and exact signature at both ends of the supported kernel range, from the upstream tags.

Once #15 merges, the four-kernel build (including the strict `CONFIG_WERROR` upstream v7.2 job) will cover this file. This is a two-line change swapping one library call for another, so the residual risk is low — but it has not been through a compiler.

## Provenance

Found by a review agent during the #15 review whose report was summarised away before it reached me; recovered by re-reading the agent transcripts. Corroborated independently by a second agent.
