### PR TITLE
fix: zero-init the HE radiotap struct, emit populated fields via put_unaligned

### DIFF
--- a/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
@@ -1363,7 +1363,12 @@ static void rwnx_rx_add_rtap_hdr(struct rwnx_hw* rwnx_hw,
         while ((pos - (u8 *)rtap) & 1)
             pos++;
         rtap->it_present |= cpu_to_le32(1 << IEEE80211_RADIOTAP_HE);
-        memcpy(pos, &he, sizeof(he));
+        /* unwritten fields keep the zero from the initial memset */
+        put_unaligned_le16(he.data1, pos);
+        put_unaligned_le16(he.data2, pos + 2);
+        put_unaligned_le16(he.data3, pos + 4);
+        put_unaligned_le16(he.data5, pos + 8);
+        put_unaligned_le16(he.data6, pos + 10);
         pos += sizeof(he);
     }
 

--- a/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
@@ -1307,7 +1307,7 @@ static void rwnx_rx_add_rtap_hdr(struct rwnx_hw* rwnx_hw,
 
     // Check for HE frames
     if (rxvect->format_mod == FORMATMOD_HE_SU) {
-        struct ieee80211_radiotap_he he;
+        struct ieee80211_radiotap_he he = {};
         #define HE_PREP(f, val) cpu_to_le16(FIELD_PREP(IEEE80211_RADIOTAP_HE_##f, val))
         #define D1_KNOWN(f) cpu_to_le16(IEEE80211_RADIOTAP_HE_DATA1_##f##_KNOWN)
         #define D2_KNOWN(f) cpu_to_le16(IEEE80211_RADIOTAP_HE_DATA2_##f##_KNOWN)


### PR DESCRIPTION
## Problem

Two defects in the HE radiotap emission inside `rwnx_rx_add_rtap_hdr()`:

1. **Uninitialised stack published to monitor frames.** `struct ieee80211_radiotap_he he;` (rwnx_rx.c:1310) is never zeroed. `data1`/`data2` are assigned, `data3`/`data5`/`data6` are built with `|=`, and `data4` (plus `data7`/`data8` on the >=4.19 8-field kernel struct) are never written. The `memcpy` at :1366 copies all of it into the radiotap header: uninitialised stack bytes leak to monitor-vif readers and HE field bits are corrupted.

2. **Fortify warning at that `memcpy`** (kernel 7.1.10-arch1-1, from the GH build workflow). The >=6.13 fortify rewrite derives a compile-time *field* size for `pos` from its provenance: `pos` = `it_present + 1`, `it_present` = `&rtap->it_present` — the tail of the 8-byte `ieee80211_radiotap_header`. `pos` sits at offset 8, past the end of that object, so `__member_size(pos)` is a constant < 16 while `sizeof(he)` is compile-time constant, and `fortify_memcpy_chk` fires `__write_overflow_field`. The destination's struct size is unknown (skb data, runtime `rtap_len`), so it is warning-only: no error, no runtime check, no hard failure unless a `CONFIG_WERROR` job surfaces it.

## Fix

- `he = {}` — zero all fields before the `|=` accumulation.
- Emit only the populated fields (`data1`, `data2`, `data3`, `data5`, `data6`) via `put_unaligned_le16`. The whole `rtap_len` region is already zeroed by the `memset` at the top of the function, so the unemitted fields correctly stay 0. Byte-identical to a zeroed `memcpy` on every kernel version, no new API surface (an `unsafe_memcpy` would not build with `FORTIFY_SOURCE=n`), and it removes the only bounds-instrumented copy in the function.

## Verification

- Honest limitation: **not build-verified locally** (macOS host, no kernel headers).
- Writer audited against `rwnx_rx_rtap_hdrlen()` across every `format_mod` x antenna combination: writes always fit `rtap_len`; tightest case is HE single-antenna at 52/52. No runtime buffer overflow — the warning is a false positive of the field-size model.
- The 4-kernel CI matrix (on main since #15) covers this file, including the strict upstream v7.2 `CONFIG_WERROR` job.
